### PR TITLE
Use PAT for scheduler dispatch

### DIFF
--- a/.github/workflows/run-scheduler.yml
+++ b/.github/workflows/run-scheduler.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 🔄 Run scheduler
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SCHEDULER_GITHUB_PAT }}
           SCHEDULER_LIMIT: ${{ inputs.limit || 1 }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}


### PR DESCRIPTION
This is needed because github token by default wouldn't result in the workflow_run event being triggered. We use this event to run the publish action after build completes.