### PR TITLE
[FEATURE] Substituting even transitive dependencies in subprojects

### DIFF
--- a/packages/client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -3,6 +3,7 @@ package org.rnrepo.tools.prebuilds
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import groovy.json.JsonSlurper
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -70,7 +71,11 @@ class PrebuildsPlugin : Plugin<Project> {
 
             // Setup
             extension.supportedPackages.forEach { packageItem ->
-                addDependency(project, "implementation", "org.rnrepo.public:${packageItem.name}:${packageItem.version}:rn${extension.reactNativeVersion}${packageItem.classifier}@aar")
+                addDependency(
+                    project,
+                    "implementation",
+                    "org.rnrepo.public:${packageItem.name}:${packageItem.version}:rn${extension.reactNativeVersion}${packageItem.classifier}@aar",
+                )
             }
 
             // Add pickFirsts due to duplicates of libworklets.so from reanimated .aar and worklets
@@ -114,24 +119,32 @@ class PrebuildsPlugin : Plugin<Project> {
             // Add substitution for supported packages for all projects and all configurations
             project.rootProject.allprojects.forEach { subproject ->
                 if (subproject == project.rootProject) return@forEach
-                val substitutionAction = Action<Project> { evaluatedProject ->
-                    extension.supportedPackages.forEach { packageItem ->
-                        val module = "org.rnrepo.public:${packageItem.name}:${packageItem.version}"
-                        evaluatedProject.configurations.all { config ->
-                            config.resolutionStrategy.dependencySubstitution { substitutions ->
-                                substitutions.all { dependencySubstitution ->
-                                    if (dependencySubstitution.requested.displayName.contains("${packageItem.name}")) {
-                                        dependencySubstitution.useTarget(substitutions.module(module))
-                                        dependencySubstitution.artifactSelection {
-                                            it.selectArtifact("aar", "aar", "rn${extension.reactNativeVersion}${packageItem.classifier}")
+                val substitutionAction =
+                    Action<Project> { evaluatedProject ->
+                        extension.supportedPackages.forEach { packageItem ->
+                            val module = "org.rnrepo.public:${packageItem.name}:${packageItem.version}"
+                            evaluatedProject.configurations.all { config ->
+                                config.resolutionStrategy.dependencySubstitution { substitutions ->
+                                    substitutions.all { dependencySubstitution ->
+                                        if (dependencySubstitution.requested.displayName.contains("${packageItem.name}")) {
+                                            dependencySubstitution.useTarget(substitutions.module(module))
+                                            dependencySubstitution.artifactSelection {
+                                                it.selectArtifact(
+                                                    "aar",
+                                                    "aar",
+                                                    "rn${extension.reactNativeVersion}${packageItem.classifier}",
+                                                )
+                                            }
+                                            logger.info(
+                                                "Adding substitution for ${packageItem.name} using $module " +
+                                                    "in config ${config.name} of project ${evaluatedProject.name}",
+                                            )
                                         }
-                                        logger.info("Adding substitution for ${packageItem.name} using $module in config ${config.name} of project ${evaluatedProject.name}")
                                     }
                                 }
                             }
                         }
                     }
-                }
                 substitutionAction.execute(subproject)
                 // TODO(radoslawrolka): keeping in case of issues with afterEvaluate
                 // if (subproject.state.executed) {
@@ -149,7 +162,11 @@ class PrebuildsPlugin : Plugin<Project> {
         defaultValue: String,
     ): String = System.getenv(propertyName) ?: project.findProperty(propertyName) as? String ?: defaultValue
 
-    private fun addDependency(project: Project, configurationName: String, dependencyNotation: String) {
+    private fun addDependency(
+        project: Project,
+        configurationName: String,
+        dependencyNotation: String,
+    ) {
         project.dependencies.add(configurationName, dependencyNotation)
         logger.info("Added dependency: $dependencyNotation to configuration: $configurationName in project ${project.name}")
     }

--- a/resources/RNRepoPlugin.js
+++ b/resources/RNRepoPlugin.js
@@ -75,5 +75,6 @@ export default function withCustomBuildSettings(config) {
   config = withClasspathDependency(config);
   config = withMavenRepository(config);
   config = withRnrepoPluginApplication(config);
+  config = withAllProjectsMavenRepository(config);
   return config;
 };


### PR DESCRIPTION
Previously, the plugin only substituted dependencies in :app, but for example react-native-reanimated is often a transitive dependency of other packages like react-native-gesture-handler. This change ensures that all subprojects have their dependencies substituted correctly.