### PR TITLE
[FIX] remove worklets 0.6.1 from reanimated

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -4,7 +4,7 @@
       {
         "versionMatcher": ["4.1.*"],
         "reactNativeVersion": "0.81.4",
-        "withWorkletsVersion": ["0.5.1", "0.6.1"]
+        "withWorkletsVersion": ["0.5.1"]
       }
     ]
   },


### PR DESCRIPTION
Due to: [Reanimated] Invalid version of `react-native-worklets`: \"0.6.1\". Expected the version to be in inclusive range \"0.5.x\".