### PR TITLE
Fix scheduler trigerring builds when multiple rows are found

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -40,15 +40,14 @@ export async function isBuildAlreadyScheduled(
     .eq('retry', false);
 
   // Filter by worklets_version if provided, otherwise check for NULL
-  if (workletsVersion !== undefined) {
-    if (workletsVersion === null) {
-      query = query.is('worklets_version', null);
-    } else {
-      query = query.eq('worklets_version', workletsVersion);
-    }
+  if (workletsVersion) {
+    query = query.eq('worklets_version', workletsVersion);
+  } else {
+    // If workletsVersion is undefined, filter for NULL to match the unique constraint behavior
+    query = query.is('worklets_version', null);
   }
 
-  const { data, error } = await query.maybeSingle();
+  const { data, error } = await query.limit(1).maybeSingle();
 
   if (error) {
     console.error(
@@ -159,4 +158,3 @@ export async function updateBuildStatus(
 
 // Re-export types
 export type { Platform, BuildStatus, BuildRecord };
-


### PR DESCRIPTION
There was an error in scheduling logic causing duplicate builds to be schedule.
The problem was in `maybeSingle` call that'd produce an error where multiple rows were returned. This shouldn't happen because we had unique constraint for package,version,platform,worklet_version, however the constraint doesn't work for records where worklets_version is NULL. As a consequence we ended up having duplicated rows which triggered the error in `maybeSingle` call.

This PR fixes the logic such that even if more than 1 rows are there, we'd still limit the call to just 1 row and return that the build has been already scheduled