### PR TITLE
Support react-native-tvos

### DIFF
--- a/packages/client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -484,6 +484,13 @@ class PrebuildsPlugin : Plugin<Project> {
                 .toSet()
     }
 
+    private fun stripVersionToCore(version: String): String {
+        // Match only the major, minor and patch versions
+        val regex = """^\d+\.\d+\.\d+""".toRegex()
+        val matchResult = regex.find(version)
+        return matchResult?.value ?: version
+    }
+
     private fun getReactNativeVersion(extension: PackagesManager): Boolean {
         // find react-native package.json
         val reactNativePackageJsonFile =
@@ -503,7 +510,7 @@ class PrebuildsPlugin : Plugin<Project> {
         // parse version
         val reactNativeVersionInfo = getPackageNameAndVersion(reactNativePackageJsonFile)
         return reactNativeVersionInfo?.let {
-            extension.reactNativeVersion = it.version
+            extension.reactNativeVersion = stripVersionToCore(it.version)
             logger.lifecycle("Detected React Native version: ${extension.reactNativeVersion}")
             true
         } ?: run {

--- a/packages/client/rnrepo-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/client/rnrepo-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -400,6 +400,30 @@ class PrebuildsPluginHelperMethodsTest {
         assertThat(result).isNull()
     }
 
+    @Test
+    fun `stripVersionToCore should handle react-native version`() {
+        // Given
+        val version = "0.81.5"
+
+        // When
+        val result = invokePrivateMethod<String>(plugin, "stripVersionToCore", arrayOf(String::class.java), version)
+
+        // Then
+        assertThat(result).isEqualTo("0.81.5")
+    }
+
+    @Test
+    fun `stripVersionToCore should handle react-native-tvos version`() {
+        // Given
+        val version = "0.81.5-0"
+
+        // When
+        val result = invokePrivateMethod<String>(plugin, "stripVersionToCore", arrayOf(String::class.java), version)
+
+        // Then
+        assertThat(result).isEqualTo("0.81.5")
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun <T> invokePrivateMethod(
         target: Any,


### PR DESCRIPTION
# Support react-native-tvos

## The problem

`react-native-tvos` version format (1.2.3-4) includes a TV OS-specific patch (-4) that conflicts with the format (1.2.3) in the supported prebuild packages.

## The solution

This PR adds the stripVersionToCore function. Which trims the `extension.reactNativeVersion`to the (1.2.3) format, ignoring the tvos specific patch version.

## Logs before:

```
> Configure project :app
[📦 RNRepo] Found React Native root directory at: /Users/konrad/work/nfl-fe
[📦 RNRepo] Detected React Native version: 0.81.5-0
```

## Logs after:

```
> Configure project :app
[📦 RNRepo] Found React Native root directory at: /Users/konrad/work/nfl-fe
[📦 RNRepo] Detected React Native version: 0.81.5
```