### PR TITLE
[CI] Apply provenance

### DIFF
--- a/.github/workflows/publish-expo-config-plugin.yml
+++ b/.github/workflows/publish-expo-config-plugin.yml
@@ -47,4 +47,4 @@ jobs:
         run: bun run prepare
 
       - name: 🚀 Publish to npm
-        run: NPM_CONFIG_PROVENANCE=false npm publish --tag beta
+        run: npm publish --tag beta


### PR DESCRIPTION
RNrepo GH repository is now public, so we can apply provenance to the packages published from this repository.