### PR TITLE
[CI] Create CI with example app to build for testing

### DIFF
--- a/.github/workflows/build-example-app.yml
+++ b/.github/workflows/build-example-app.yml
@@ -13,8 +13,8 @@ on:
           - snapshots
         required: true
         default: 'releases'
-      android_gradle_plugin_version:
-        description: 'Android Gradle Plugin version'
+      rnrepo_prebuilds_plugin_version:
+        description: 'RNRepo prebuilds-plugin version'
         required: false
         type: string
         default: '0.1.0'
@@ -74,7 +74,7 @@ jobs:
         working-directory: ${{ env.EXAMPLE_APP }}
 
       - name: 🛠 Add RNRepo to gradle
-        run: bun run .github/workflows/scripts/applyRNRepoAndroid.ts ${{ env.EXAMPLE_APP }}/android ${{ github.event.inputs.android_gradle_plugin_version }} ${{ github.event.inputs.maven_repository_type }}
+        run: bun run .github/workflows/scripts/applyRNRepoAndroid.ts ${{ env.EXAMPLE_APP }}/android ${{ github.event.inputs.rnrepo_prebuilds_plugin_version }} ${{ github.event.inputs.maven_repository_type }}
 
       - name: 🏗 Build Example App with RNRepo
         run: ./gradlew :app:assembleDebug --info

--- a/.github/workflows/scripts/applyRNRepoAndroid.ts
+++ b/.github/workflows/scripts/applyRNRepoAndroid.ts
@@ -1,18 +1,18 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-// Get android directory, plugin version, and maven repository type from command line arguments
+// Get android directory, RNRepo prebuilds-plugin version, and maven repository type from command line arguments
 if (process.argv.length < 5) {
-  console.error('❌ Usage: bun run applyRNRepoAndroid.ts <android_directory> <android_gradle_plugin_version> <maven_repository_type>');
+  console.error('❌ Usage: bun run applyRNRepoAndroid.ts <android_directory> <rnrepo_plugin_version> <maven_repository_type>');
   process.exit(1);
 }
 const androidDir = process.argv[2];
-const androidGradlePluginVersion = process.argv[3];
+const rnrepoPluginVersion = process.argv[3];
 const mavenRepositoryType = process.argv[4] as 'releases' | 'snapshots';
 
 // Configuration constants
 const classpathRegex = /(classpath.*)/;
-const rnrepoClasspath = `classpath("org.rnrepo.tools:prebuilds-plugin:${androidGradlePluginVersion}")`;
+const rnrepoClasspath = `classpath("org.rnrepo.tools:prebuilds-plugin:${rnrepoPluginVersion}")`;
 const mavenCentralRepository = `mavenCentral()`;
 const mavenRepositoryBlock = `
     maven { url "https://packages.rnrepo.org/${mavenRepositoryType}" }`;
@@ -161,7 +161,7 @@ function modifyAppBuildGradle(appBuildGradlePath: string): void {
  * Main function - apply RNRepo configuration to Android project
  */
 function applyRNRepoConfiguration(androidDir: string): void {
-  console.log(`🛠  Applying RNRepo configuration to: ${androidDir}`);
+  console.log(`🛠 Applying RNRepo configuration to: ${androidDir}`);
 
   const projectBuildGradlePath = path.join(androidDir, 'build.gradle');
   const appBuildGradlePath = path.join(androidDir, 'app', 'build.gradle');


### PR DESCRIPTION
CI allows to build the Example App with RNRepo integration.
Configurable input parameters:
- maven_repository_type: Type of Maven repository to use for RNRepo artifacts. Can be either "releases" or "snapshots".
- android_gradle_plugin_version: Version of Android Gradle Plugin to use in the Example App
- libraries: Comma-separated list of libraries to install in the Example App before building it:
  - lib1@version,lib2@version
- react_native_version: Version of React Native.

Example dispatch: https://github.com/software-mansion/rnrepo/actions/runs/19970796671