### PR TITLE
Fix index name to avoid errors when updating

### DIFF
--- a/packages/database/supabase/migrations/20251210103000_fix_unique_index_nulls_not_distinct.sql
+++ b/packages/database/supabase/migrations/20251210103000_fix_unique_index_nulls_not_distinct.sql
@@ -1,0 +1,20 @@
+-- Migration: Align unique index with ON CONFLICT columns
+-- Created: 2025-12-10
+-- Description: Replace expression-based unique index with a column-based
+--              unique index using NULLS NOT DISTINCT so upsert on
+--              (package_name, version, rn_version, platform, worklets_version)
+--              matches the constraint when worklets_version is NULL.
+
+-- Remove the previous expression index
+DROP INDEX IF EXISTS idx_builds_unique;
+
+-- Create a unique index that treats NULLs as equal for worklets_version
+CREATE UNIQUE INDEX IF NOT EXISTS idx_builds_unique
+ON builds (
+  package_name,
+  version,
+  rn_version,
+  platform,
+  worklets_version
+) NULLS NOT DISTINCT;
+


### PR DESCRIPTION
This PR updates the database schema to use identifiable unique index instead of the previous index that would use coalesce to dedupe NULL values. This is important as we reference the key when inserting and hence we were using fields the insert query resulted in an error.

## 🎯 Type of Change

Please delete options that are not relevant:
- 🐛 Bug fix (non-breaking change which fixes an issue)