### PR TITLE
[CI] Allow for client snapshot publishing

### DIFF
--- a/.github/workflows/publish-plugin-android.yml
+++ b/.github/workflows/publish-plugin-android.yml
@@ -4,6 +4,12 @@ run-name: Publish RNRepo Gradle Plugin for Android
 
 on:
   workflow_dispatch:
+    inputs:
+      snapshot:
+        description: 'Publish as snapshot version to /snapshots repository'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-rnrepo-plugin-android:
@@ -22,7 +28,7 @@ jobs:
           ./gradlew publishReleasePublicationToRnrepoRepository --no-daemon \
           -PmavenUsername=${{ secrets.RNREPO_SWM_PUBLISHER_USERNAME }} \
           -PmavenPassword=${{ secrets.RNREPO_SWM_PUBLISHER_TOKEN }} \
-          -PmavenRepositoryUrl=${{ secrets.RNREPO_SWM_REPOSITORY_URL }} \
+          -PmavenRepositoryUrl=${{ inputs.snapshot && secrets.RNREPO_SWM_REPOSITORY_URL_SNAPSHOTS || secrets.RNREPO_SWM_REPOSITORY_URL }} \
           -PsigningKey="${{ secrets.GPG_PRIVATE_KEY }}" \
           -PsigningPassword="${{ secrets.GPG_PASSPHRASE }}"
         working-directory: ./packages/client/rnrepo-plugin


### PR DESCRIPTION
## 📝 Description

Now RNRepo Gradle Plugin for Android can be published to repository /snapshots

Fixes: #(issue number if applicable)

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)