### PR TITLE
Add spec for reanimated 4.2

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -13,9 +13,13 @@
     "description": "React Native animation library",
     "android": [
       {
-        "versionMatcher": "*",
+        "versionMatcher": "<4.2",
         "withWorkletsVersion": ["0.5.1", "0.6.1"],
         "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.2",
+        "withWorkletsVersion": ["0.7.1"]
       }
     ]
   },


### PR DESCRIPTION
Reanimated 4.2 seems to require worklets 0.7.1 – the current builds for reanimated are failing because we only compile it against 0.6.1 and 0.5.1