### PR TITLE
Enhancemenets to Supported Libraries page

### DIFF
--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -89,13 +89,16 @@ import Logo from './Logo.astro';
         <a href="/#setup" class="hover:text-rnrGrey-0 transition-colors">
           Setup
         </a>
-        <a href="/#benefits" class="hover:text-rnrGrey-0 transition-colors">
-          Benefits
-        </a>
         <a href="/#how-it-works" class="hover:text-rnrGrey-0 transition-colors">
           How It Works
         </a>
         <a href="/#faq" class="hover:text-rnrGrey-0 transition-colors">FAQ</a>
+        <a
+          href="/supported-libraries"
+          class="hover:text-rnrGrey-0 transition-colors"
+        >
+          Supported Libraries
+        </a>
       </div>
 
       <div>

--- a/packages/website/src/components/Navbar.astro
+++ b/packages/website/src/components/Navbar.astro
@@ -1,6 +1,6 @@
 ---
 import Logo from './Logo.astro';
-import { Menu, X } from 'lucide-astro';
+import { Github, Menu, X } from 'lucide-astro';
 ---
 
 <nav
@@ -20,21 +20,18 @@ import { Menu, X } from 'lucide-astro';
       </div>
 
       <div
-        class="hidden md:flex items-center space-x-8 text-sm font-medium text-rnrGrey-40"
+        class="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-medium text-rnrGrey-40 whitespace-nowrap"
       >
-        <a href="/#setup" class="hover:text-rnrGrey-0 transition-colors">
+        <a href="/#setup" class="hover:text-rnrGrey-0 transition-colors whitespace-nowrap">
           Setup
         </a>
-        <a href="/#benefits" class="hover:text-rnrGrey-0 transition-colors">
-          Benefits
-        </a>
-        <a href="/#how-it-works" class="hover:text-rnrGrey-0 transition-colors">
+        <a href="/#how-it-works" class="hover:text-rnrGrey-0 transition-colors whitespace-nowrap">
           How It Works
         </a>
-        <a href="/#faq" class="hover:text-rnrGrey-0 transition-colors"> FAQ </a>
+        <a href="/#faq" class="hover:text-rnrGrey-0 transition-colors whitespace-nowrap"> FAQ </a>
         <a
           href="/supported-libraries"
-          class="hover:text-rnrGrey-0 transition-colors"
+          class="hover:text-rnrGrey-0 transition-colors whitespace-nowrap"
         >
           Supported Libraries
         </a>
@@ -43,10 +40,16 @@ import { Menu, X } from 'lucide-astro';
           href="https://github.com/software-mansion/rnrepo"
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-2 bg-surfaceHighlight hover:bg-rnrGrey-60 text-rnrGrey-0 px-4 py-2 rounded-sm border border-rnrGrey-60 transition-all text-xs uppercase tracking-wide"
+          aria-label="View RNRepo on GitHub"
+          title="View RNRepo on GitHub"
+          class="flex items-center gap-2 bg-surfaceHighlight hover:bg-rnrGrey-60 text-rnrGrey-0 px-3 py-2 rounded-sm border border-rnrGrey-60 transition-all text-xs uppercase tracking-wide whitespace-nowrap"
         >
-          View on GitHub
-          <span class="text-rnrGrey-40">→</span>
+          {/* Mid-width: icon-only */}
+          <Github class="w-4 h-4 lg:hidden" />
+          {/* Wide: original label + arrow */}
+          <span class="hidden lg:inline">View on GitHub</span>
+          <span class="hidden lg:inline text-rnrGrey-40">→</span>
+          <span class="sr-only">View on GitHub</span>
         </a>
       </div>
 
@@ -74,13 +77,6 @@ import { Menu, X } from 'lucide-astro';
           data-mobile-menu-link
         >
           Setup
-        </a>
-        <a
-          href="/#benefits"
-          class="block text-sm font-medium text-rnrGrey-40 hover:text-rnrGrey-0 transition-colors py-2"
-          data-mobile-menu-link
-        >
-          Benefits
         </a>
         <a
           href="/#how-it-works"

--- a/packages/website/src/components/SupportedLibraries.astro
+++ b/packages/website/src/components/SupportedLibraries.astro
@@ -221,21 +221,23 @@ const supportedLibraryNames = await getSupportedLibraryNames();
                       <>
                         {libInfo.android_versions &&
                         libInfo.android_versions.length > 0 ? (
-                          <div class="android-versions-wrapper flex flex-wrap gap-2">
-                            {libInfo.android_versions.map((ver) => (
-                              <span class="version-tag android-version inline-flex items-center px-2 py-1 rounded-sm text-xs font-medium bg-brandSeaBlue-100/10 text-brandSeaBlue-100">
-                                {ver}
-                              </span>
-                            ))}
-                            {libInfo.android_versions &&
-                              libInfo.android_versions.length > 3 && (
-                                <button
-                                  class="expand-android-btn inline-flex items-center px-2 py-1 rounded-sm text-xs font-medium text-rnrGrey-40 hover:text-brandSeaBlue-100 transition-colors cursor-pointer"
-                                  aria-expanded="false"
-                                >
-                                  {/* text is set client-side based on viewport */}
-                                </button>
-                              )}
+                          <div class="android-versions-wrapper flex items-center gap-2 w-full min-w-0">
+                            <div class="android-versions-list flex flex-nowrap gap-2 overflow-hidden">
+                              {libInfo.android_versions.map((ver) => (
+                                <span class="version-tag android-version inline-flex items-center px-2 py-1 rounded-sm text-xs font-medium bg-brandSeaBlue-100/10 text-brandSeaBlue-100 flex-shrink-0">
+                                  {ver}
+                                </span>
+                              ))}
+                              {libInfo.android_versions &&
+                                libInfo.android_versions.length > 3 && (
+                                  <button
+                                    class="expand-android-btn inline-flex items-center px-2 py-1 rounded-sm text-xs font-medium text-rnrGrey-40 hover:text-brandSeaBlue-100 transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
+                                    aria-expanded="false"
+                                  >
+                                    {/* text is set client-side based on viewport */}
+                                  </button>
+                                )}
+                            </div>
                           </div>
                         ) : (
                           <span class="android-empty text-xs text-rnrGrey-40 italic">
@@ -411,28 +413,37 @@ const supportedLibraryNames = await getSupportedLibraryNames();
     });
   }
 
-  function getMaxVisibleAndroidVersions(): number {
-    // Give the name column more room on mid-width screens.
-    // - <lg: show up to 3 tags
-    // - lg+: show up to 4 tags
-    return window.matchMedia('(min-width: 1024px)').matches ? 4 : 3;
+  function getFlexGapPx(el: HTMLElement): number {
+    const styles = window.getComputedStyle(el);
+    // Prefer columnGap when present; fall back to gap.
+    const raw =
+      styles.columnGap && styles.columnGap !== 'normal'
+        ? styles.columnGap
+        : styles.gap;
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
   }
 
   function applyAndroidVersionsCollapse(wrapper: Element): void {
+    const list = wrapper.querySelector(
+      '.android-versions-list'
+    ) as HTMLElement | null;
     const versions = Array.from(
       wrapper.querySelectorAll<HTMLElement>('.android-version')
     );
     const expandBtn = wrapper.querySelector<HTMLButtonElement>(
       '.expand-android-btn'
     );
-    if (versions.length === 0) return;
+    if (!list || versions.length === 0) return;
 
-    const maxVisible = getMaxVisibleAndroidVersions();
     const isExpanded =
       wrapper.getAttribute('data-expanded') === 'true' ||
       expandBtn?.getAttribute('aria-expanded') === 'true';
 
     if (isExpanded) {
+      // Expanded: show everything; allow wrapping (it can take multiple lines).
+      list.classList.remove('flex-nowrap', 'overflow-hidden');
+      list.classList.add('flex-wrap');
       versions.forEach((v) => {
         v.hidden = false;
         v.classList.remove('android-hidden');
@@ -446,12 +457,83 @@ const supportedLibraryNames = await getSupportedLibraryNames();
       return;
     }
 
-    let hiddenCount = 0;
+    // Collapsed: keep a single line and show only as many pills as fit in the
+    // available width next to the "+N more" button (so we never crop).
+    list.classList.remove('flex-wrap');
+    list.classList.add('flex-nowrap', 'overflow-hidden');
+
+    // Make everything visible for measurement without flashing.
+    const previousVisibility = list.style.visibility;
+    list.style.visibility = 'hidden';
+    versions.forEach((v) => {
+      v.hidden = false;
+      v.classList.remove('android-hidden');
+    });
+
+    const listWidth = list.clientWidth;
+    const gap = getFlexGapPx(list);
+
+    // If everything fits without the button, hide it and show all pills.
+    let allFitWithoutButton = true;
+    let usedAll = 0;
+    for (let i = 0; i < versions.length; i++) {
+      const pillW = versions[i].offsetWidth;
+      usedAll = i === 0 ? pillW : usedAll + gap + pillW;
+      if (usedAll > listWidth - 1) {
+        allFitWithoutButton = false;
+        break;
+      }
+    }
+    if (expandBtn && allFitWithoutButton) {
+      expandBtn.hidden = true;
+      expandBtn.textContent = '';
+    }
+
+    let visibleCount = versions.length;
+
+    if (expandBtn && !allFitWithoutButton) {
+      expandBtn.hidden = false;
+
+      // Iterate a few times because the button label width depends on the hiddenCount.
+      // This converges quickly and maximizes visible pills.
+      let lastVisibleCount = -1;
+      let buttonW = 0;
+
+      for (let iter = 0; iter < 4; iter++) {
+        const hiddenGuess =
+          iter === 0
+            ? versions.length
+            : Math.max(0, versions.length - visibleCount);
+        expandBtn.textContent = `+${hiddenGuess} more`;
+        buttonW = expandBtn.offsetWidth;
+
+        let used = 0;
+        visibleCount = 0;
+
+        for (let i = 0; i < versions.length; i++) {
+          const pillW = versions[i].offsetWidth;
+          const nextUsed = visibleCount === 0 ? pillW : used + gap + pillW;
+          const totalWithButton = nextUsed + gap + buttonW;
+
+          if (totalWithButton <= listWidth - 1) {
+            used = nextUsed;
+            visibleCount++;
+            continue;
+          }
+          break;
+        }
+
+        if (visibleCount === lastVisibleCount) break;
+        lastVisibleCount = visibleCount;
+      }
+    }
+
+    const hiddenCount = Math.max(0, versions.length - visibleCount);
+
     versions.forEach((v, idx) => {
-      const shouldHide = idx >= maxVisible;
+      const shouldHide = idx >= visibleCount;
       v.hidden = shouldHide;
       v.classList.toggle('android-hidden', shouldHide);
-      if (shouldHide) hiddenCount++;
     });
 
     if (expandBtn) {
@@ -463,7 +545,9 @@ const supportedLibraryNames = await getSupportedLibraryNames();
         expandBtn.hidden = true;
       }
     }
+
     wrapper.setAttribute('data-expanded', 'false');
+    list.style.visibility = previousVisibility;
   }
 
   function setupAndroidVersionsCollapse(): void {

--- a/packages/website/src/data/fetch-supported-libraries.ts
+++ b/packages/website/src/data/fetch-supported-libraries.ts
@@ -18,6 +18,24 @@ const MOCK_LIBRARIES: LibrariesData = {
       name: '@react-native-firebase/app',
       android_versions: ['21.6.0'],
     },
+    'react-native-super-long-versions': {
+      name: 'react-native-super-long-versions',
+      android_versions: [
+        '1.0.0',
+        '1.1.0',
+        '1.2.0',
+        '1.3.0',
+        '1.4.0',
+        '1.5.0',
+        '1.6.0',
+        '1.7.0',
+        '1.8.0',
+        '1.9.0',
+        '1.10.0',
+        '1.11.0',
+        '1.12.0',
+      ],
+    },
   },
   '0.73.0': {
     'react-native-reanimated': {
@@ -31,6 +49,24 @@ const MOCK_LIBRARIES: LibrariesData = {
     '@react-native-firebase/app': {
       name: '@react-native-firebase/app',
       android_versions: ['21.5.0', '21.6.0'],
+    },
+    'react-native-super-long-versions': {
+      name: 'react-native-super-long-versions',
+      android_versions: [
+        '0.90.0',
+        '0.91.0',
+        '0.92.0',
+        '0.93.0',
+        '0.94.0',
+        '0.95.0',
+        '0.96.0',
+        '0.97.0',
+        '0.98.0',
+        '0.99.0',
+        '0.100.0',
+        '0.101.0',
+        '0.102.0',
+      ],
     },
   },
 };

--- a/packages/website/src/styles/global.css
+++ b/packages/website/src/styles/global.css
@@ -2,3 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Ensure the HTML `hidden` attribute always hides elements, even when display utility
+   classes (e.g. `flex`, `inline-flex`) are present. */
+[hidden] {
+  display: none !important;
+}
+


### PR DESCRIPTION
Brings some enhancements and fixes to supported libraries page:
1) render table items in multiple-rows on mobile
2) add padding between beta notice block
3) don't show the number of libraries more than once
4) fix weird highlighting of version buttons
5) remove "benefits" from navbar and add "supported libraries" to footer
6) add library list mock used in dev mode (such that we don't need to have db credentials when developing)
7) fix navbar wrapping text in mid-width – we now use github icon instead of "view on github" in mid-width windows
