### PR TITLE
[FIX] bump worklets and reanimated for RNGH with latest RN versions

### DIFF
--- a/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
+++ b/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
@@ -3,11 +3,17 @@ import { $ } from 'bun';
 export default async function postInstallSetup(): Promise<void> {
     console.log(`Running post-install setup for react-native-gesture-handler...`);
     
+    const rnVersion = await getPackageVersion('react-native');
+    console.log(`Detected React Native version: ${rnVersion}`);
+    const reanimatedVersion = getReanimatedVersion(rnVersion);
+    console.log(`Determined compatible react-native-reanimated version: ${reanimatedVersion}`);
+    const workletsVersion = getWorkletsVersion(reanimatedVersion);
+    console.log(`Determined compatible react-native-worklets version: ${workletsVersion}`);
     // Support RN-GH only with reanimated
-    await $`bun install react-native-reanimated@4.0.0 --save-exact`.quiet();
-    console.log('✓ Installed react-native-reanimated@4.0.0');
-    await $`bun install react-native-worklets@0.4.0 --save-exact`.quiet();
-    console.log('✓ Installed react-native-worklets@0.4.0');
+    await $`bun install react-native-reanimated@${reanimatedVersion} --save-exact`.quiet();
+    console.log(`✓ Installed react-native-reanimated@${reanimatedVersion}`);
+    await $`bun install react-native-worklets@${workletsVersion} --save-exact`.quiet();
+    console.log(`✓ Installed react-native-worklets@${workletsVersion}`);
     // Patch react-native-gesture-handler to avoid issues with react-native-svg
     await $`bun install react-native-svg`.quiet();
     console.log('✓ Installed react-native-svg');
@@ -18,6 +24,25 @@ export default async function postInstallSetup(): Promise<void> {
     
     console.log(`✓ Post-install setup for react-native-gesture-handler completed.`);
 };
+
+async function getPackageVersion(packageName: string): Promise<string> {
+    const packageJsonPath = `node_modules/${packageName}/package.json`;
+    try {
+        const packageJson = JSON.parse(await Bun.file(packageJsonPath).text());
+        return packageJson.version;
+    } catch (error) {
+        console.error(`Error retrieving version for package ${packageName}:`, error);
+        throw error;
+    }
+}
+
+function getReanimatedVersion(rnVersion: string): string {
+    return rnVersion.startsWith('0.8') ? '4.1.4' : '4.0.0';
+}
+
+function getWorkletsVersion(reanimatedVersion: string): string {
+    return reanimatedVersion === '4.1.4' ? '0.6.1' : '0.4.0';
+}
 
 try {
     await postInstallSetup();


### PR DESCRIPTION
## 📝 Description

[FIX] bump worklets and reanimated for RNGH with latest RN versions

https://github.com/software-mansion/rnrepo/actions/runs/19910715318/job/57078443782

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce.

`bun run packages/builder/build-library-android.ts -- "react-native-gesture-handler" "2.28.0" "0.82.0" "tempGH_plus2"`
