### PR TITLE
[website] Small visual fixes to RN version selector on Supported libs page

### DIFF
--- a/packages/website/src/components/SupportedLibraries.astro
+++ b/packages/website/src/components/SupportedLibraries.astro
@@ -59,7 +59,9 @@ const supportedLibraryNames = await getSupportedLibraryNames();
     </div>
 
     {/* React Native Versions Card */}
-    <div class="rounded-lg border border-rnrGrey-80 bg-surface/40 p-6 mb-8">
+    <div
+      class="rounded-lg border border-rnrGrey-80 bg-surface/40 px-4 py-6 mb-8"
+    >
       <div class="flex flex-col gap-4">
         <div>
           <h2 class="text-lg font-semibold text-rnrGrey-0">
@@ -94,11 +96,7 @@ const supportedLibraryNames = await getSupportedLibraryNames();
               </button>
             )
           }
-          <div
-            id="rn-versions-list"
-            class="rn-versions-hidden flex flex-wrap gap-2 w-full items-center"
-            hidden
-          >
+          <div id="rn-versions-list" class="rn-versions-hidden contents" hidden>
             {
               allRNVersions.slice(5).map((version) => (
                 <button
@@ -113,7 +111,7 @@ const supportedLibraryNames = await getSupportedLibraryNames();
             }
             <button
               id="collapse-rn-versions"
-              class="collapse-rn-btn px-3 py-1 inline-flex items-center justify-center rounded-sm text-xs font-medium text-rnrGrey-40 hover:text-brandSeaBlue-100 transition-colors cursor-pointer whitespace-nowrap ml-auto"
+              class="collapse-rn-btn px-3 py-1 inline-flex items-center justify-center rounded-sm text-xs font-medium text-rnrGrey-40 hover:text-brandSeaBlue-100 transition-colors cursor-pointer whitespace-nowrap"
             >
               show less
             </button>
@@ -591,6 +589,12 @@ const supportedLibraryNames = await getSupportedLibraryNames();
     } else {
       noResults?.classList.add('hidden');
     }
+
+    // Recalculate version wrapping for visible libraries
+    const visibleWrappers = document.querySelectorAll(
+      '.library-row:not([style*="display: none"]) .android-versions-wrapper'
+    );
+    visibleWrappers.forEach((w) => applyAndroidVersionsCollapse(w));
   }
 
   // Handle version button clicks

--- a/packages/website/src/data/fetch-supported-libraries.ts
+++ b/packages/website/src/data/fetch-supported-libraries.ts
@@ -5,6 +5,119 @@ import {
 } from '@rnrepo/database';
 
 const MOCK_LIBRARIES: LibrariesData = {
+  '0.76.0': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.16.0', '3.16.1'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.20.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.10.0'],
+    },
+  },
+  '0.75.8': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.15.0', '3.15.1', '3.15.2'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.19.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.9.0'],
+    },
+  },
+  '0.75.5': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.15.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.18.1', '2.19.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.8.0'],
+    },
+  },
+  '0.75.2': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.14.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.18.0', '2.18.1'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.7.0', '21.8.0'],
+    },
+  },
+  '0.75.0': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.13.0', '3.14.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.17.0', '2.18.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.7.0'],
+    },
+  },
+  '0.74.5': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.12.0', '3.12.1'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.16.2', '2.17.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.6.0'],
+    },
+    'react-native-super-long-versions': {
+      name: 'react-native-super-long-versions',
+      android_versions: [
+        '1.5.0',
+        '1.5.1',
+        '1.5.2',
+        '1.5.3',
+        '1.5.4',
+        '1.5.5',
+        '1.5.6',
+        '1.5.7',
+        '1.5.8',
+        '1.5.9',
+      ],
+    },
+  },
+  '0.74.3': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.11.0', '3.12.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.16.0', '2.16.1', '2.16.2'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.6.0'],
+    },
+  },
   '0.74.0': {
     'react-native-reanimated': {
       name: 'react-native-reanimated',
@@ -37,6 +150,62 @@ const MOCK_LIBRARIES: LibrariesData = {
       ],
     },
   },
+  '0.73.9': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.10.0', '3.10.1'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.15.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.5.0', '21.6.0'],
+    },
+  },
+  '0.73.6': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.9.0', '3.10.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.14.1', '2.15.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.5.0'],
+    },
+  },
+  '0.73.4': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.8.0', '3.9.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.14.0', '2.14.1'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.4.0', '21.5.0'],
+    },
+  },
+  '0.73.2': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.7.0', '3.8.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.13.4', '2.14.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.3.0', '21.4.0'],
+    },
+  },
   '0.73.0': {
     'react-native-reanimated': {
       name: 'react-native-reanimated',
@@ -67,6 +236,48 @@ const MOCK_LIBRARIES: LibrariesData = {
         '0.101.0',
         '0.102.0',
       ],
+    },
+  },
+  '0.72.10': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.5.0', '3.5.4'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.12.0', '2.13.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.2.0'],
+    },
+  },
+  '0.72.7': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.4.0', '3.5.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.11.0', '2.12.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.1.0', '21.2.0'],
+    },
+  },
+  '0.72.5': {
+    'react-native-reanimated': {
+      name: 'react-native-reanimated',
+      android_versions: ['3.3.0', '3.4.0'],
+    },
+    'react-native-gesture-handler': {
+      name: 'react-native-gesture-handler',
+      android_versions: ['2.10.0', '2.11.0'],
+    },
+    '@react-native-firebase/app': {
+      name: '@react-native-firebase/app',
+      android_versions: ['21.0.0', '21.1.0'],
     },
   },
 };


### PR DESCRIPTION
This PR addresses the following issues:
1) Layout of versions blocks in "RN Versions" container was broken and the versions block were wrapped in weird way + the "show less" was always right-aligned. We are now using simple layout to display all the blocks along with the "show more/less" button
2) After changing RN versions, we need to recalculate library version wrapping. This is because some RN versions may yield less than 3 library versions for certain libraries while other can have more than 3 versions. We need to update library wrapping when RN version changes and when we display library versions for that particular RN version.

We are also adding more RN versions to test data such that the described problems can be noticed in dev mode.