### PR TITLE
[FIX] Change mistaken npmName to name in gradle plugin

### DIFF
--- a/packages/gradle-client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/gradle-client/rnrepo-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -516,7 +516,7 @@ class PrebuildsPlugin : Plugin<Project> {
                 logger.info("Checking availability of package ${packageItem.npmName} version ${packageItem.version} at $urlString")
                 val isAvailable = connection.responseCode == HttpURLConnection.HTTP_OK
                 if (isAvailable) {
-                    logger.info("✓ Package ${packageItem.name}@${packageItem.version} found at ${repo.url}")
+                    logger.info("✓ Package ${packageItem.npmName}@${packageItem.version} found at ${repo.url}")
                 }
                 isAvailable
             } catch (e: Exception) {


### PR DESCRIPTION
## 📝 Description

[FIX] Change mistaken npmName to name in gradle plugin
Fix: #174

## 🎯 Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
