### PR TITLE
Add head_branch to failed publishes

### DIFF
--- a/.github/workflows/publish-library-android.yml
+++ b/.github/workflows/publish-library-android.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: 🏗 Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/publish-library-ios.yml
+++ b/.github/workflows/publish-library-ios.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: 🏗 Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
## 📝 Description

When build failed then publish build was launched from main branch instead of the same branch as build job. It was done for successful jobs (L51), so this was missing.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)