### PR TITLE
Add react-native-theoplayer support

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -527,8 +527,7 @@
   "react-native-theoplayer": {
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
+        "versionMatcher": ">=10.9"
       }
     ]
   }


### PR DESCRIPTION
## 📝 Description

Adds support for [react-native-theoplayer](https://www.npmjs.com/package/react-native-theoplayer?activeTab=readme)

The Licence is corrected from version 10.9.0 onward, hence the `versionMatcher`

## 🎯 Type of Change

- [x] 🧩 New library support

## 🧪 Testing

```sh
$ bun run build-library-android.ts react-native-theoplayer "10.9.0" "0.81.4" /tmp/TEMP_MASKED
...
✅ Successfully built AAR for react-native-theoplayer@10.9.0 with RN 0.81.4
```
