### PR TITLE
Temporarily disable scheduler schedule for storage migration

### DIFF
--- a/.github/workflows/run-scheduler.yml
+++ b/.github/workflows/run-scheduler.yml
@@ -8,9 +8,9 @@ on:
         required: false
         type: number
         default: 1
-  schedule:
-    # Runs every 4 hours at minute 0 (6 times per day)
-    - cron: '0 */4 * * *'
+  # schedule:
+  #   # Runs every 4 hours at minute 0 (6 times per day)
+  #   - cron: '0 */4 * * *'
 
 jobs:
   run-scheduler:


### PR DESCRIPTION
We are performing a storage migration and need to disable scheduler temporarily such that it doesn enqueue any actions that would publish artifacts during migration