### PR TITLE
Fix error builds for prebuilded RN < 0.81.1

### DIFF
--- a/packages/builder/build-library-ios.ts
+++ b/packages/builder/build-library-ios.ts
@@ -274,11 +274,16 @@ async function buildLibrary() {
     // This is available as early as RN 0.74.0 so safe to use here
     console.log('📦 Running pod install with static frameworks...');
     const iosPath = join(appDir, 'ios');
+
+    // Use prebuilt React Native core for RN >= 0.81.1
+    // issue: https://github.com/expo/expo/issues/38990
+    const usePrebuiltRNVersion = reactNativeVersion >= '0.81.1' ? '1' : '0';
+    
     await $`pod install`.cwd(iosPath).env({
       ...process.env,
       USE_FRAMEWORKS: 'static',
-      USE_PREBUILT_REACT_NATIVE: '1', // Use prebuilt React Native to speed up builds
-      RCT_USE_RN_DEP: '1', // Use RN dependency management
+      USE_PREBUILT_REACT_NATIVE: usePrebuiltRNVersion, // Use prebuilt React Native to speed up builds(for RN >= 0.81.1)
+      RCT_USE_RN_DEP: usePrebuiltRNVersion, // Use RN dependency management
     });
     console.log('✓ Pod install completed with static frameworks');
 


### PR DESCRIPTION
## 📝 Description

Switched to building React Native from source (<0.81.1) to resolve pod install failures associated with pre-built iOS binaries during the library prebuild phase. (https://github.com/expo/expo/issues/38990)

```
~ pod install
...
Error:
[!] /bin/bash -c
set -e
CURRENT_PATH=$(pwd)
mkdir -p Headers
XCFRAMEWORK_PATH=$(find "$CURRENT_PATH" -type d -name "ReactNativeDependencies.xcframework")
HEADERS_PATH=$(find "$XCFRAMEWORK_PATH" -type d -name "Headers" | head -n 1)
cp -R "$HEADERS_PATH/" Headers
mkdir -p framework/packages/react-native
cp -R "$XCFRAMEWORK_PATH/.." framework/packages/react-native/
find "$XCFRAMEWORK_PATH/.." -type f -exec rm {} +
find "$CURRENT_PATH" -type d -empty -delete

cp: framework/packages/react-native/..: File exists
```

## 🎯 Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)