### PR TITLE
Remove temporarily from scheduler

### DIFF
--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -17,7 +17,7 @@ export async function processLibrary(
 ): Promise<number> {
   console.log(`\n📦 Processing: ${libraryName}`);
 
-  const platforms: Platform[] = ['android', 'ios'];
+  const platforms: Platform[] = ['android']; // TODO: add ios when CI runner will be available
   const rnVersions = reactNativeVersions as string[];
   let scheduledCount = currentCount;
 


### PR DESCRIPTION
## 📝 Description

Most of ci jobs fails without proper macos runner, so ios builds have to be launched with manual control, so i would like to temporarily remove ios from scheduler and build just android (new 0.84 RN batches) for a moment.