### PR TITLE
increase timeout-limit for ios builder to 120min

### DIFF
--- a/.github/workflows/build-library-ios.yml
+++ b/.github/workflows/build-library-ios.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   build-library-ios:
     runs-on: macos-latest-xlarge
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - name: 🏗 Checkout repository


### PR DESCRIPTION
## 📝 Description

Avoid actions failing at the end of the build process due to a 60-minute cancellation timeout

## 🎯 Type of Change
- [x] ⚡ Performance improvement=
