### PR TITLE
remove testing xcframework from download link

### DIFF
--- a/packages/build-tools/cocoapods-plugin/lib/downloader.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/downloader.rb
@@ -19,7 +19,7 @@ module CocoapodsRnrepo
 
     def self.build_artifact_url(artifact_spec)
       worklets_suffix = artifact_spec[:worklets_version] ? "-worklets#{artifact_spec[:worklets_version]}" : ''
-      "#{@@repo_url}/org/rnrepo/public/#{artifact_spec[:sanitized_name]}/#{artifact_spec[:version]}/#{artifact_spec[:sanitized_name]}-#{artifact_spec[:version]}-rn#{artifact_spec[:rn_version]}#{worklets_suffix}-#{artifact_spec[:configuration]}.xcframework.zip"
+      "#{@@repo_url}/org/rnrepo/public/#{artifact_spec[:sanitized_name]}/#{artifact_spec[:version]}/#{artifact_spec[:sanitized_name]}-#{artifact_spec[:version]}-rn#{artifact_spec[:rn_version]}#{worklets_suffix}-#{artifact_spec[:configuration]}.zip"
     end
 
     def self.build_http_client(uri, read_timeout)


### PR DESCRIPTION
## 📝 Description

Artifact are stored without 'xcframework' in name: https://packages.rnrepo.org/releases/org/rnrepo/public/react-native-svg/15.11.2/react-native-svg-15.11.2-rn0.78.3-debug.zip

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)