### PR TITLE
bump gradle to 0.3.0 for npm package release

### DIFF
--- a/packages/build-tools/gradle-plugin/build.gradle
+++ b/packages/build-tools/gradle-plugin/build.gradle
@@ -9,7 +9,7 @@ plugins {
 group = 'org.rnrepo.tools'
 
 // Fixed version in code - automatically appends -SNAPSHOT for local publishes
-def baseVersion = '0.2.2'
+def baseVersion = '0.3.0'
 def isLocalPublish = project.gradle.startParameter.taskNames.any {
     it.contains("MavenLocal")
 }

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -19,7 +19,7 @@
   "files": [
     "cocoapods-plugin/",
     "gradle-plugin/README.md",
-    "gradle-plugin/build/libs/prebuilds-plugin-0.2.2.jar",
+    "gradle-plugin/build/libs/prebuilds-plugin-0.3.0.jar",
     "README.md"
   ],
   "keywords": [


### PR DESCRIPTION
## 📝 Description

Bump gradle plugin version for release as new minor 0.3.0

## 🎯 Type of Change

- [x] 📚 Documentation update