### PR TITLE
Fallback worklets&reanimated to sources when one not supported

### DIFF
--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -812,15 +812,10 @@ class PrebuildsPlugin : Plugin<Project> {
         dependentList.parallelStream().forEach { packageItem ->
             logger.info("Handling ${packageItem.npmName} package after others.")
             val elseClosure: () -> Unit = {
-                // Worklets and Reanimated works in release builds when worklets would not be substituted with aar.
-                if (getBuildType(project) == "release" && packageItem.name == "react-native-worklets") {
-                    supportedPackages.add(packageItem)
-                } else {
-                    logger.info(
-                        "${packageItem.npmName} has dependencies with C++ code, checking availability of dependent packages...",
-                    )
-                    checkDependenciesLocal(packageItem, project, supportedPackages, unavailablePackages, extension.projectPackages)
-                }
+                logger.info(
+                    "${packageItem.npmName} has dependencies with C++ code, checking availability of dependent packages...",
+                )
+                checkDependenciesLocal(packageItem, project, supportedPackages, unavailablePackages, extension.projectPackages)
             }
             checkIfPackageIsSupported(packageItem, project.repositories, extension, unavailablePackages, elseClosure)
         }


### PR DESCRIPTION
## 📝 Description

In previous versions, Reanimated and Worklets functioned correctly in release builds even without AAR support for one of the packages. However, due to failure mentioned in #266, it should temporarily fallback to building from source - similar to Firebase libraries - until the root cause is identified.
- RN@0.83.2
- worklets@0.7.1
- reanimated@4.2.1

Issue: #266 

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)