### PR TITLE
Add  firebase/firestore to android build list

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -731,5 +731,14 @@
         "versionMatcher": ">=10.9"
       }
     ]
+  },
+  "@react-native-firebase/firestore": {
+    "postInstallScriptPath": "postInstallScripts/@react-native-firebase/firestore/react-native-firebase_firestore.ts",
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ]
   }
 }

--- a/postInstallScripts/@react-native-firebase/firestore/react-native-firebase_firestore.ts
+++ b/postInstallScripts/@react-native-firebase/firestore/react-native-firebase_firestore.ts
@@ -1,0 +1,28 @@
+import { $ } from 'bun';
+
+export default async function postInstallSetup(): Promise<void> {
+    console.log(`Running post-install setup for @react-native-firebase/firestore...`);
+    
+    const react_native_firebase_firestore_version = await getPackageVersion('@react-native-firebase/firestore');
+    await $`bun install @react-native-firebase/app@${react_native_firebase_firestore_version} --save-exact`.quiet();
+    
+    console.log(`✓ Post-install setup for @react-native-firebase/firestore completed.`);
+};
+
+async function getPackageVersion(packageName: string): Promise<string> {
+    const packageJsonPath = `node_modules/${packageName}/package.json`;
+    try {
+        const packageJson = JSON.parse(await Bun.file(packageJsonPath).text());
+        return packageJson.version;
+    } catch (error) {
+        console.error(`Error retrieving version for package ${packageName}:`, error);
+        throw error;
+    }
+}
+
+try {
+    await postInstallSetup();
+} catch (error) {
+    console.error('Error during post-install setup:', error);
+    throw error;
+}


### PR DESCRIPTION
## 📝 Description

- added firebase/firestore to libraries.json with android config
- added postinstall script (same as other firebase postinstall scripts)

Adding firebase/firestore to android building list, since we did not test the firestore on ios yet.

#275 

## 🎯 Type of Change

- [x] 🧩 New library support

## 🧪 Testing

```
$ bun run build-android @react-native-firebase/firestore 23.8.6 0.81.4 TEMP_FIREBASE-FIRESTORE
...
44 actionable tasks: 44 executed
✓ Published to Maven Local successfully
✅ Successfully built AAR for @react-native-firebase/firestore@23.8.6 with RN 0.81.4
```
also builded successfully example rn-app with firestore