### PR TITLE
schedule 50 builds per scheduler cron

### DIFF
--- a/.github/workflows/run-scheduler.yml
+++ b/.github/workflows/run-scheduler.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 🔄 Run scheduler
         env:
           GITHUB_TOKEN: ${{ secrets.SCHEDULER_GITHUB_PAT }}
-          SCHEDULER_LIMIT: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.limit || 1) || 200 }}
+          SCHEDULER_LIMIT: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.limit || 1) || 50 }} # TODO: change back to 200 when we have custom macos runner
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: bun run scheduler


### PR DESCRIPTION
## 📝 Description

- avg one build at macos-xlarge = 20min
- max concurent jobs on macos = 5
- scheduler cron = every 4h
So limit should be (20/60) * 5 * 4 ~= 50 (calculated with advantage to include failures that takes less time and nighttime with less occupancy)

Revert this change when we have custom macos runner (#280).

## 🎯 Type of Change

- [x] ⚡ Performance improvement
