### PR TITLE
Replace the `rubyzip` dependency with `system("unzip", ...)`.

### DIFF
--- a/packages/build-tools/cocoapods-plugin/lib/downloader.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/downloader.rb
@@ -1,6 +1,5 @@
 require 'net/http'
 require 'uri'
-require 'fileutils'
 
 module CocoapodsRnrepo
   class Downloader


### PR DESCRIPTION
## Summary

This removes the external dependency on `rubyzip`. Using `system("unzip", ...)` is safe here because the code is designed to run only on macOS, where `unzip` is available by default.

## Testing
```
[📦 RNRepo] Extracting to /Users/radoslawrolka/BUILDLE_ANDROID/rnrepo/AwesomeProject_UNZIP/node_modules/react-native-safe-area-context/.rnrepo-cache/Release...
[📦 RNRepo] Extracted successfully
[📦 RNRepo] Found XCFramework: react_native_safe_area_context.xcframework
```
Fixes #286