### PR TITLE
Remove worklets classifier from reanimated

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -82,9 +82,14 @@
         "publishedAfterDate": "2025-01-01"
       },
       {
-        "versionMatcher": ">=4.2.2",
+        "versionMatcher": ">=4.2.2 <4.3.0",
         "reactNativeVersion": ">=0.80",
         "withWorkletsVersion": ["0.7"],
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.3.0",
+        "reactNativeVersion": ">=0.81",
         "publishedAfterDate": "2025-01-01"
       }
     ],
@@ -138,9 +143,14 @@
         "publishedAfterDate": "2025-01-01"
       },
       {
-        "versionMatcher": ">=4.2.2",
+        "versionMatcher": ">=4.2.2 <4.3.0",
         "reactNativeVersion": ">=0.80",
         "withWorkletsVersion": ["0.7"],
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.3.0",
+        "reactNativeVersion": ">=0.81",
         "publishedAfterDate": "2025-01-01"
       }
     ]

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -39,6 +39,12 @@ def get_ios_denylist(workspace_root)
   denylist_config['ios'] || []
 end
 
+def is_version_at_least(current_version, minimum_version)
+  current_version ||= '0.0.0'
+  current_core = current_version.match(/^\d+(\.\d+)*/)&.to_s || '0.0.0'
+  Gem::Version.new(current_core) >= Gem::Version.new(minimum_version)
+end
+
 def rnrepo_pre_install(installer_context)
   # Check if plugin is disabled via environment variable
   if ENV['DISABLE_RNREPO']
@@ -69,7 +75,9 @@ def rnrepo_pre_install(installer_context)
 
   # Add worklets version to reanimated pod info
   if (pod = rn_pods.find { |p| p[:name] == 'RNReanimated' })
-    pod[:worklets_version] = worklets_version
+    if is_version_at_least(pod[:version], "4.3.0")
+      pod[:worklets_version] = worklets_version
+    end
   end
 
   if rn_pods.empty?

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -75,7 +75,7 @@ def rnrepo_pre_install(installer_context)
 
   # Add worklets version to reanimated pod info
   if (pod = rn_pods.find { |p| p[:name] == 'RNReanimated' })
-    if is_version_at_least(pod[:version], "4.3.0")
+    if !is_version_at_least(pod[:version], "4.3.0")
       pod[:worklets_version] = worklets_version
     end
   end

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -600,6 +600,26 @@ class PrebuildsPlugin : Plugin<Project> {
         return matchResult?.value ?: version
     }
 
+    private fun isVersionAtLeast(
+        current: String,
+        minimum: String,
+    ): Boolean {
+        val currentParts = current.split(".").map { it.toIntOrNull() ?: 0 }
+        val minParts = minimum.split(".").map { it.toIntOrNull() ?: 0 }
+
+        val maxLength = maxOf(currentParts.size, minParts.size)
+
+        for (i in 0 until maxLength) {
+            val currentPart = currentParts.getOrElse(i) { 0 }
+            val minPart = minParts.getOrElse(i) { 0 }
+
+            if (currentPart > minPart) return true
+            if (currentPart < minPart) return false
+        }
+
+        return true
+    }
+
     private fun getReactNativeVersion(extension: PackagesManager): Boolean {
         // find react-native package.json
         val reactNativePackageJsonFile =
@@ -648,6 +668,12 @@ class PrebuildsPlugin : Plugin<Project> {
                 if (packageItem.version.startsWith("3.")) {
                     logger.info(
                         "react-native-reanimated: Version ${packageItem.version} is 3.x, no worklets package needed.",
+                    )
+                    return true
+                }
+                if (isVersionAtLeast(packageItem.version, "4.3.0")) {
+                    logger.info(
+                        "react-native-reanimated: Version ${packageItem.version} is 4.3.0 or higher, no worklets classifier needed.",
                     )
                     return true
                 }

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -283,7 +283,7 @@ class PrebuildsPluginHelperMethodsTest {
     fun `isSpecificCheckPassed should handle react-native-reanimated with worklets`() {
         // Given
         val extension = PackagesManager()
-        val reanimatedPackage = PackageItem("react-native-reanimated", "4.5.0", "react-native-reanimated")
+        val reanimatedPackage = PackageItem("react-native-reanimated", "4.2.0", "react-native-reanimated")
         val workletsPackage = PackageItem("react-native-worklets", "1.0.0", "react-native-worklets")
         extension.projectPackages = setOf(reanimatedPackage, workletsPackage)
         val supportedPackages = mutableSetOf<PackageItem>()
@@ -310,7 +310,7 @@ class PrebuildsPluginHelperMethodsTest {
     fun `isSpecificCheckPassed should handle react-native-reanimated without worklets`() {
         // Given
         val extension = PackagesManager()
-        val reanimatedPackage = PackageItem("react-native-reanimated", "4.5.0", "react-native-reanimated")
+        val reanimatedPackage = PackageItem("react-native-reanimated", "4.2.0", "react-native-reanimated")
         extension.projectPackages = setOf(reanimatedPackage)
         val supportedPackages = mutableSetOf<PackageItem>()
         val mockProject = setupPluginExecution(listOf("assembleDebug"), null, false)
@@ -329,6 +329,31 @@ class PrebuildsPluginHelperMethodsTest {
 
         // Then
         assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isSpecificCheckPassed should handle react-native-reanimated4-3-0 without worklets`() {
+        // Given
+        val extension = PackagesManager()
+        val reanimatedPackage = PackageItem("react-native-reanimated", "4.5.0", "react-native-reanimated")
+        extension.projectPackages = setOf(reanimatedPackage)
+        val supportedPackages = mutableSetOf<PackageItem>()
+        val mockProject = setupPluginExecution(listOf("assembleDebug"), null, false)
+
+        // When
+        val result =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "isSpecificCheckPassed",
+                arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
+                reanimatedPackage,
+                extension,
+                supportedPackages,
+                mockProject,
+            )
+
+        // Then
+        assertThat(result).isTrue()
     }
 
     @Test


### PR DESCRIPTION
## 📝 Description

With the release of `react-native-reanimated@4.3.0`, the library introduced a stable API that eliminates the need for version-specific builds tied to `react-native-worklets`. Previously, the tooling built a full variant matrix tied to specific worklets classifiers - this is no longer required for `4.3.0+`. 
- The `>=4.2.2` version range in libraries.json was capped to `<4.3.0`, and a new entry without a worklets classifier was added for `>=4.3.0`. 
- Both the Gradle and CocoaPods plugins were updated to skip worklets resolution entirely when reanimated `>= 4.3.0` is detected.

## 🎯 Type of Change

- [x] ⚡ Performance improvement