### PR TITLE
Add explicit worklets installation for reanimated@4.3.0+

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -32,6 +32,7 @@
     ]
   },
   "react-native-reanimated": {
+    "postInstallScriptPath": "postInstallScripts/react-native-reanimated/react-native-reanimated.ts",
     "android": [
       {
         "versionMatcher": "3.16",

--- a/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
+++ b/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
@@ -1,0 +1,43 @@
+import { $ } from 'bun';
+import semver from 'semver';
+
+const COMPATIBILITY_MATRIX = [
+  {
+    reanimated: '>=4.3.0 <4.4.0',
+    worklets: '0.8.1'
+  },
+];
+
+export default async function postInstallSetup(): Promise<void> {
+    console.log(`Running post-install setup for react-native-reanimated...`);
+    
+    const reanimatedVersion = await getPackageVersion('react-native-reanimated');
+    console.log(`Detected react-native-reanimated version: ${reanimatedVersion}`);
+    const workletsVersion = COMPATIBILITY_MATRIX.find(m => semver.satisfies(reanimatedVersion, m.reanimated))?.worklets;
+    if (!workletsVersion) {
+        throw new Error(`Unsupported react-native-reanimated version: ${reanimatedVersion}. Please check the compatibility matrix.`);
+    }
+    // install react-native-worklets
+    await $`bun install react-native-worklets@${workletsVersion} --save-exact`.quiet();
+    console.log(`✓ Installed react-native-worklets@${workletsVersion}`);
+ 
+    console.log(`✓ Post-install setup for react-native-reanimated completed.`);
+};
+
+async function getPackageVersion(packageName: string): Promise<string> {
+    const packageJsonPath = `node_modules/${packageName}/package.json`;
+    try {
+        const packageJson = JSON.parse(await Bun.file(packageJsonPath).text());
+        return packageJson.version;
+    } catch (error) {
+        console.error(`Error retrieving version for package ${packageName}:`, error);
+        throw error;
+    }
+}
+
+try {
+    await postInstallSetup();
+} catch (error) {
+    console.error('Error during post-install setup:', error);
+    throw error;
+}

--- a/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
+++ b/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
@@ -13,8 +13,12 @@ export default async function postInstallSetup(): Promise<void> {
     
     const reanimatedVersion = await getPackageVersion('react-native-reanimated');
     console.log(`Detected react-native-reanimated version: ${reanimatedVersion}`);
+    if (semver.satisfies(reanimatedVersion, '<4.3.0')) {
+        console.log(`For react-native-reanimated@<4.3.0 react-native-worklets are added as CLI argument. Skipping.`);
+        return;
+    }
     const workletsVersion = COMPATIBILITY_MATRIX.find(m => semver.satisfies(reanimatedVersion, m.reanimated))?.worklets;
-    if (!workletsVersion && semver.satisfies(reanimatedVersion, '>=4.3.0')) {
+    if (!workletsVersion) {
         throw new Error(`Unsupported react-native-reanimated version: ${reanimatedVersion}. Please check the compatibility matrix.`);
     }
     // install react-native-worklets

--- a/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
+++ b/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
@@ -3,7 +3,7 @@ import semver from 'semver';
 
 const COMPATIBILITY_MATRIX = [
   {
-    reanimated: '>=4.3.0 <4.4.0',
+    reanimated: '>=4.3.0',
     worklets: '0.8.1'
   },
 ];
@@ -14,7 +14,7 @@ export default async function postInstallSetup(): Promise<void> {
     const reanimatedVersion = await getPackageVersion('react-native-reanimated');
     console.log(`Detected react-native-reanimated version: ${reanimatedVersion}`);
     const workletsVersion = COMPATIBILITY_MATRIX.find(m => semver.satisfies(reanimatedVersion, m.reanimated))?.worklets;
-    if (!workletsVersion) {
+    if (!workletsVersion && semver.satisfies(reanimatedVersion, '>=4.3.0')) {
         throw new Error(`Unsupported react-native-reanimated version: ${reanimatedVersion}. Please check the compatibility matrix.`);
     }
     // install react-native-worklets


### PR DESCRIPTION

## 📝 Description

Pod install failed when worklets were installed as a peer dependency

I’d avoid tying this to the old `workletsVersion` approach in `libraries.json`, since that was a reanimated-specific addition for its build process. Now that reanimated has been decoupled from worklets, that field is likely to be removed in the future

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)