### PR TITLE
bump versions before release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/build-tools": {
       "name": "@rnrepo/build-tools",
-      "version": "0.1.0",
+      "version": "0.1.3-beta.0",
     },
     "packages/builder": {
       "name": "@rnrepo/builder",
@@ -64,11 +64,11 @@
     },
     "packages/expo-config-plugin": {
       "name": "@rnrepo/expo-config-plugin",
-      "version": "0.3.0-beta.0",
+      "version": "0.3.0-beta.3",
       "dependencies": {
         "@expo/config-plugins": "*",
         "@expo/config-types": "*",
-        "@rnrepo/build-tools": "0.1.0",
+        "@rnrepo/build-tools": "0.1.3-beta.0",
       },
       "devDependencies": {
         "expo-module-scripts": "^5.0.7",

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.1.3-beta.0] - 2026-04-23
 
 ### Added
 - Added support for ExpoModulesCore in Android release builds (#301)

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.3-beta.0] - 2026-04-23
+## [0.1.3-beta.0] - 2026-04-30
 
 ### Added
 - Added support for ExpoModulesCore in Android release builds (#301)

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/build-tools",
   "title": "RNRepo Prebuilds plugin",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.3-beta.0",
   "description": "RNRepo plugin for handling prebuilt binaries of iOS and Android libraries",
   "scripts": {
     "build": "./gradle-plugin/gradlew build --no-daemon -p gradle-plugin",

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0-beta.3] - 2026-04-23
+
+### Changed
+- Bumped @rnrepo/build-tools dependency to 0.1.3-beta.0 (#325)
+
 ## [0.3.0-beta.2] - 2026-03-26
 
 ### Changed

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0-beta.3] - 2026-04-23
+## [0.3.0-beta.3] - 2026-04-30
 
 ### Changed
 - Bumped @rnrepo/build-tools dependency to 0.1.3-beta.0 (#325)

--- a/packages/expo-config-plugin/package.json
+++ b/packages/expo-config-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/expo-config-plugin",
   "title": "RNRepo expo config plugin",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "description": "Plugin for configuring RNRepo prebuilt packages in Expo projects",
   "sideEffects": false,
   "main": "build/withRNRepoPlugin.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/config-plugins": "*",
     "@expo/config-types": "*",
-    "@rnrepo/build-tools": "0.1.2-beta.0"
+    "@rnrepo/build-tools": "0.1.3-beta.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"


### PR DESCRIPTION
## 📝 Description

Release:
- support for EMC
- new reanimated@+4.3.0 support
- incorporated maven url into plugin

## Tested

- Projects: 
    - `$ npx create-expo-app@latest --template default@sdk-54 my-app-54`
    - `$ npx create-expo-app@latest --template default@sdk-55 my-app-55`
    - `$ npx @react-native-community/cli@latest init AwesomeProject_84 --version 0.84.0`
    - `$ npx @react-native-community/cli@latest init AwesomeProject_85 --version 0.85.0`
- With packages:
    - react-native-worklets@0.8.0 / 0.7.4
    - react-native-reanimated@4.3.0 / 4.2.3
- Scenarios:
    - apps without added maven url in build.gradle are pulling packages correctly (new feature)
    - react-native@0.85 on iOS works (new fix)
    - worklets classifier is not added on 4.3.0 reanimated (new feature)
    - worklets classifier is added on <4.3.0 reanimated (no regression test)
    - emc is prebuilt in expo android release builds
- Building:
    - `$ ./gradlew :app:assembleDebug`
    - `$ ./gradlew :app:assembleRelease`
    - ``
- Results: (`-` means not applicable)
    - expo@54
        - android: ✅ / - / - / ✅ / ✅
        - ios: - / - / - / ✅ / -
    - expo@55:
        - android: ✅ / - / - / ✅ / ✅
        - ios: - / - / - / ✅ / -
    - react-native@0.84:
        - android: ✅ / - / ✅ / ✅ / -
        - ios: - / - / ✅ / ✅ / -
    - react-native@0.85:
        - android: ✅ / - / ✅ / - / -
        - ios: - / ✅ / ✅ / - / -
