### PR TITLE
lock the mvn cli version used in publisher

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Worklets classifier is no longer added in reanimated@4.3.0+ artifacts (#317)
 - Incorporate RNRepo maven url inside gradle plugin (#270)
+- iOS plugin looks now for artifacts named '<>.xcframework.zip' (#327)
 
 ### Fixed
 - Added dummy header for iOS pods source_files (#311)

--- a/packages/build-tools/cocoapods-plugin/lib/downloader.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/downloader.rb
@@ -14,7 +14,7 @@ module CocoapodsRnrepo
 
     def self.build_artifact_url(artifact_spec)
       worklets_suffix = artifact_spec[:worklets_version] ? "-worklets#{artifact_spec[:worklets_version]}" : ''
-      "#{@@repo_url}/org/rnrepo/public/#{artifact_spec[:sanitized_name]}/#{artifact_spec[:version]}/#{artifact_spec[:sanitized_name]}-#{artifact_spec[:version]}-rn#{artifact_spec[:rn_version]}#{worklets_suffix}-#{artifact_spec[:configuration]}.zip"
+      "#{@@repo_url}/org/rnrepo/public/#{artifact_spec[:sanitized_name]}/#{artifact_spec[:version]}/#{artifact_spec[:sanitized_name]}-#{artifact_spec[:version]}-rn#{artifact_spec[:rn_version]}#{worklets_suffix}-#{artifact_spec[:configuration]}.xcframework.zip"
     end
 
     # Download file via curl

--- a/packages/database/src/check-build-consistency.ts
+++ b/packages/database/src/check-build-consistency.ts
@@ -34,7 +34,7 @@ function buildArtifactUrl(
 
   const variants = build.platform === 'android' 
     ? ['.aar'] 
-    : ['-debug.zip', '-release.zip'];
+    : ['-debug.xcframework.zip', '-release.xcframework.zip'];
   return variants.map(suffix => `${commonPath}/${encodeURIComponent(fileName + suffix)}`);
 }
 

--- a/packages/publisher/publish-library-android.ts
+++ b/packages/publisher/publish-library-android.ts
@@ -157,7 +157,7 @@ async function main() {
     // Sign and deploy AAR using gpg:sign-and-deploy-file (signs and deploys in one step)
     // The task uses MAVEN_GPG_KEY and MAVEN_GPG_PASSPHRASE environment variables to sign the artifact
     let publishStatus = 'failed' as 'failed' | 'completed';
-    const result = await $`mvn org.apache.maven.plugins:maven-gpg-plugin:3.1.3:sign-and-deploy-file \
+    const result = await $`mvn org.apache.maven.plugins:maven-gpg-plugin:3.2.8:sign-and-deploy-file \
         -Dfile=${aarFile} \
         -DgroupId=org.rnrepo.public \
         -DartifactId=${mavenLibraryName} \

--- a/packages/publisher/publish-library-android.ts
+++ b/packages/publisher/publish-library-android.ts
@@ -132,7 +132,7 @@ async function main() {
 
     // Deploy POM separately (may return 409 if already published, which is acceptable)
     try {
-      await $`mvn deploy:deploy-file \
+      await $`mvn org.apache.maven.plugins:maven-deploy-plugin:3.1.4:deploy-file \
           -Dfile=${pomFile} \
           -DgroupId=org.rnrepo.public \
           -DartifactId=${mavenLibraryName} \
@@ -157,7 +157,7 @@ async function main() {
     // Sign and deploy AAR using gpg:sign-and-deploy-file (signs and deploys in one step)
     // The task uses MAVEN_GPG_KEY and MAVEN_GPG_PASSPHRASE environment variables to sign the artifact
     let publishStatus = 'failed' as 'failed' | 'completed';
-    const result = await $`mvn gpg:sign-and-deploy-file \
+    const result = await $`mvn org.apache.maven.plugins:maven-gpg-plugin:3.1.3:sign-and-deploy-file \
         -Dfile=${aarFile} \
         -DgroupId=org.rnrepo.public \
         -DartifactId=${mavenLibraryName} \

--- a/packages/publisher/publish-library-ios.ts
+++ b/packages/publisher/publish-library-ios.ts
@@ -131,7 +131,7 @@ async function main() {
       // Deploy the XCFramework zip to Maven repository
       // Using the same Maven infrastructure as Android for cross-platform compatibility
       console.log('\n🚀 Deploying to Maven repository...');
-      await $`mvn deploy:deploy-file \
+      await $`mvn org.apache.maven.plugins:maven-deploy-plugin:3.1.4:deploy-file \
           -Dfile=${xcframeworkPath} \
           -DgroupId=org.rnrepo.public \
           -DartifactId=${sanitizedLibraryName} \


### PR DESCRIPTION

## 📝 Description

In `mvn deploy-file`, the `-packaging` argument was not used in version 3.1.2 (bug) which was fixed in later versions (currently worklfow uses 3.1.4). apache/maven-deploy-plugin/issues/576

It caused the iOS artifacts to be deployed with various extensions:
- old and wrong: `<artifact-name>.zip`
- new and correct: `<artifact-name>.xcframework.zip` 

What have been done:
- lock the version of mvn:deploy-file to 3.1.4 and gpg to 3.2.8 to avoid issue mentioned above 
  - versions locked on are same as currently used
- updated all `.zip` uses to be `.xcframework.zip`

BREAKING CHANGE:
- RENAMED (reupload) all existing artifacts on maven that are named `^.*(?<!\.xcframework)\.zip$` to `.xcframework.zip`

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- builds:
  - android: 
    - build: https://github.com/software-mansion/rnrepo/actions/runs/25054559013
    - publish: https://github.com/software-mansion/rnrepo/actions/runs/25054727591
  - ios: 
    - build: https://github.com/software-mansion/rnrepo/actions/runs/25053999050
    - publish: https://github.com/software-mansion/rnrepo/actions/runs/25054114005
  - artifacts: https://packages.rnrepo.org/snapshots/org/rnrepo/public/react-native-firebase_app/23.5.0