### PR TITLE
Allow packages to be resolved from locations beyond `node_modules`

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Worklets classifier is no longer added in reanimated@4.3.0+ artifacts (#317)
 - Incorporate RNRepo maven url inside gradle plugin (#270)
+- Allow Android packages to be resolved from locations beyond `node_modules` (#328)
 
 ### Fixed
 - Added dummy header for iOS pods source_files (#311)

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for ExpoModulesCore in Android release builds (#301)
+- Allow Android packages to be resolved from locations beyond `node_modules` (#328)
 
 ### Changed
 - Worklets classifier is no longer added in reanimated@4.3.0+ artifacts (#317)
 - Incorporate RNRepo maven url inside gradle plugin (#270)
 - iOS plugin looks now for artifacts named '<>.xcframework.zip' (#327)
-- Allow Android packages to be resolved from locations beyond `node_modules` (#328)
 
 ### Fixed
 - Added dummy header for iOS pods source_files (#311)

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -620,13 +620,12 @@ class PrebuildsPlugin : Plugin<Project> {
         extension.projectPackages =
             allprojects
                 .map { it.projectDir }
-                .filter { it.absolutePath.contains("node_modules") }
                 .map { File(it.parentFile, "package.json") }
                 .filter { it.exists() }
                 .mapNotNull { getPackageNameAndVersion(it) }
                 .toSet()
         logger.info(
-            "Detected ${extension.projectPackages.size} packages in project under node_modules: " +
+            "Detected ${extension.projectPackages.size} packages in project: " +
                 extension.projectPackages.joinToString("") { "\n  - ${it.name}@${it.version}" },
         )
     }
@@ -694,7 +693,9 @@ class PrebuildsPlugin : Plugin<Project> {
     ): Boolean {
         when (packageItem.name) {
             "react-native-gesture-handler" -> {
-                val isReanimatedPresent = extension.projectPackages.any { it.name == "react-native-reanimated" }
+                val isReanimatedPresent =
+                    extension.projectPackages.any { it.name == "react-native-reanimated" } ||
+                        project.rootProject.allprojects.any { it.name == "react-native-reanimated" }
                 if (!isReanimatedPresent) {
                     logger.info(
                         "react-native-gesture-handler: react-native-reanimated not found in project, using react-native-gesture-handler from sources.",

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -83,7 +83,7 @@ class PrebuildsPlugin : Plugin<Project> {
         if (shouldPluginExecute(project, extension)) {
             // Check what packages are in project and which are we supporting
             addRNRepoRepository(project)
-            getProjectPackages(project.rootProject.allprojects, extension)
+            getProjectPackages(project.rootProject.subprojects, extension)
             loadDenyList(extension)
             determineSupportedPackages(project, extension)
 
@@ -693,9 +693,7 @@ class PrebuildsPlugin : Plugin<Project> {
     ): Boolean {
         when (packageItem.name) {
             "react-native-gesture-handler" -> {
-                val isReanimatedPresent =
-                    extension.projectPackages.any { it.name == "react-native-reanimated" } ||
-                        project.rootProject.allprojects.any { it.name == "react-native-reanimated" }
+                val isReanimatedPresent = extension.projectPackages.any { it.name == "react-native-reanimated" }
                 if (!isReanimatedPresent) {
                     logger.info(
                         "react-native-gesture-handler: react-native-reanimated not found in project, using react-native-gesture-handler from sources.",


### PR DESCRIPTION
## 📝 Description

For example, inside a react-native-reanimated repository itself symlinks to react-native-reanimated package exist in `node_modules`, while the actual source is located in `packages/` - this results in react-native-gesture-handler builded from sources due to the illusionary absence of react-native-reanimated in project

- removed required `node_modules` from package's absolute path
- changed `allprojects` to `subprojects` to exclude app's gradle project from being tried to be substituted

## 🎯 Type of Change

- [x] ⚡ Performance improvement
