### PR TITLE
ci: build plugin before using in project

### DIFF
--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -109,6 +109,10 @@ jobs:
         run: ./gradlew build
         working-directory: packages/build-tools/gradle-plugin
 
+      - name: 🏗 Build expo plugin
+        run: bun run build
+        working-directory: packages/expo-config-plugin
+
       - name: 🛠 Prebuild for Android
         run: bunx expo prebuild --platform android --clean
         working-directory: ${{ env.EXAMPLE_APP }}
@@ -156,6 +160,10 @@ jobs:
           example_app: ${{ env.EXAMPLE_APP }}
           expo_sdk_major_version: ${{ env.EXPO_SDK_MAJOR_VERSION }}
           disable_rnrepo: ${{ github.event.inputs.disable_rnrepo }}
+
+      - name: 🏗 Build expo plugin
+        run: bun run build
+        working-directory: packages/expo-config-plugin
 
       - name: 🛠 Prebuild for iOS
         run: bunx expo prebuild --platform ios --clean


### PR DESCRIPTION
## 📝 Description

build ts code before running it. it was failing in some ci runs:
```
PluginError: Unable to resolve a valid config plugin for @rnrepo/expo-config-plugin.
• main export of @rnrepo/expo-config-plugin does not appear to be a config plugin: the following error was thrown when importing /home/runner/work/rnrepo/rnrepo/packages/expo-config-plugin/app.plugin.js: Cannot find module './build/withRNRepoPlugin'
```

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
