### PR TITLE
trigger builds only when PR is labeled

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ Please include a summary of the changes and related context. Explain the **why**
 
 [hidden-comment]: <> (Update changelog if needed)
 [hidden-comment]: <> (Mention related issues if applicable)
+[hidden-comment]: <> (To trigger the regression build tests, add `build-android`/`build-ios`/`build-expo` labels to the pull request)
 
 ## 🎯 Type of Change
 

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -39,7 +39,9 @@ env:
 
 jobs:
   check-changes:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios", "build-expo"]'), github.event.label.name))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [labeled]
   workflow_dispatch:
     inputs:
       expo_sdk_major_version:
@@ -38,6 +39,7 @@ env:
 
 jobs:
   check-changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -71,7 +73,10 @@ jobs:
 
   build-example-expo-app-android:
     needs: check-changes
-    if: needs.check-changes.outputs.android == 'true' || github.event.inputs.request_android == 'true'
+    if: >-
+      (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
+      (github.event_name == 'pull_request' && contains(fromJSON('["build-android", "build-expo"]'), github.event.label.name))
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -124,7 +129,10 @@ jobs:
 
   build-example-expo-app-ios:
     needs: check-changes
-    if: needs.check-changes.outputs.ios == 'true' || github.event.inputs.request_ios == 'true'
+    if: >-
+      (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
+      (github.event_name == 'pull_request' && contains(fromJSON('["build-ios", "build-expo"]'), github.event.label.name))
     runs-on: [self-hosted, macOS, ARM64, ephemeral]
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -45,7 +45,9 @@ env:
 
 jobs:
   check-changes:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios"]'), github.event.label.name))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [labeled]
   workflow_dispatch:
     inputs:
       rn_version:
@@ -44,6 +45,7 @@ env:
 
 jobs:
   check-changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -75,7 +77,10 @@ jobs:
 
   build-example-rn-app-android:
     needs: check-changes
-    if: needs.check-changes.outputs.android == 'true' || github.event.inputs.request_android == 'true'
+    if: >-
+      (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
+      (github.event_name == 'pull_request' && contains(fromJSON('["build-android"]'), github.event.label.name))
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -124,7 +129,10 @@ jobs:
 
   build-example-rn-app-ios:
     needs: check-changes
-    if: needs.check-changes.outputs.ios == 'true' || github.event.inputs.request_ios == 'true'
+    if: >-
+      (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
+      (github.event_name == 'pull_request' && contains(fromJSON('["build-ios"]'), github.event.label.name))
     runs-on: [self-hosted, macOS, ARM64, ephemeral]
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## 📝 Description

Reduce unnecessary builds runs for prs that change comments or minor stuff.

#### Code explanation

```
  check-changes:

    # this allows to run jobs on main-push and workflow_dispatch or non-draft PRs 
    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
```


```
    if: >-
      # this trigger building on main after pr merging when changes are in android plugin
      (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
     
      # this trigger building via manual dispatch and requires android checkbox selected
      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
      
      # this trigger building on open PR (non-draft) only when correct labels are added, so workflow will not run for unnecessary changes. 
      # this is main reason
      (github.event_name == 'pull_request' && contains(fromJSON('["build-android", "build-expo"]'), github.event.label.name))
```

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)