### PR TITLE
bump versions before release and removed beta labels

### DIFF
--- a/.github/actions/setup-expo-example-app/action.yml
+++ b/.github/actions/setup-expo-example-app/action.yml
@@ -47,9 +47,11 @@ runs:
       run: bun install --ignore-scripts
       working-directory: ${{ inputs.example_app }}
 
+      # runs npm due to `error: @rnrepo/build-tools@<not-existing-version> failed to resolve`
+      # testing before release after the version bump was impossible
     - name: 📦 Install @rnrepo/build-tools and @rnrepo/expo-config-plugin
       shell: bash
-      run: bun add ../packages/build-tools ../packages/expo-config-plugin
+      run: npm install ../packages/build-tools ../packages/expo-config-plugin
       working-directory: ${{ inputs.example_app }}
 
     - name: 🔧 Add plugin to app.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RNRepo is an infrastructure and tooling project from [Software Mansion](https://swmansion.com) that improves native build times in React Native projects by pre-building and distributing community library artifacts. We maintain both the automated build system that precompiles popular React Native libraries and the distribution network that hosts these artifacts. With seamless integration via build plugins, RNRepo can reduce your build times by up to **2×** with zero infrastructure changes.
 
-> ⚠️ RNRepo is currently in beta and available only for React Native projects using **The New Architecture**. Please give it a try, share your feedback and use [issues](https://github.com/software-mansion/rnrepo/issues) to report any problems with your setup.
+> RNRepo is available only for React Native projects using **The New Architecture**. Please give it a try, share your feedback and use [issues](https://github.com/software-mansion/rnrepo/issues) to report any problems with your setup.
 
 To get started quickly, head to the [Installation](#installation) section or visit [RNRepo.org](https://rnrepo.org) for instructions.
 
@@ -177,8 +177,6 @@ For more detailed troubleshooting instructions, please refer to the [Troubleshoo
 
 ## Limitations
 
-RNRepo is currently in beta, and while we're working to improve compatibility, the current version has certain limitations:
-
 1. **Local build modifications:** If you have local build-time modifications of React Native core or any library code in the form of patches (via patch-package) or build-time feature flags, the prebuilt artifacts may not be compatible with your configuration. In this case, you'll need to explicitly opt out of using prebuilds for specific libraries. If you have a use case where you'd like to use prebuilt patched libraries, reach out to [Software Mansion](https://swmansion.com/contact) to help customize the setup for you.
 2. **Limited React Native versions supported:** We support all React Native versions from `0.80.0` onwards, plus the latest patch versions for `0.77.3`, `0.78.3`, and `0.79.7`. If your React Native version is not yet supported, prebuilt artifacts will automatically fall back to building from source. For a complete list of supported versions, refer to the `react-native-versions.json` file in our GitHub repository.
 3. **Limited library coverage:** We host a limited subset of community libraries for specific React Native versions. Refer to `libraries.json` file for the complete list of supported libraries. We're actively expanding coverage (see the section below on adding new libraries).
@@ -188,7 +186,7 @@ RNRepo is currently in beta, and while we're working to improve compatibility, t
 
 ## Adding new libraries to RNRepo
 
-As RNRepo is currently in beta, we are still expanding the list of libraries that we can cover.
+We are still expanding the list of libraries that we can cover.
 If you'd like us to add a specific library or React Native version, you can submit an [issue](https://github.com/software-mansion/rnrepo/issues), keep in mind that the library needs to meet the following requirements:
 
 1. It needs to have some platform native code (JS/TS only libraries won't benefit from pre-builds anyway).

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/build-tools": {
       "name": "@rnrepo/build-tools",
-      "version": "0.1.3-beta.0",
+      "version": "0.1.4",
     },
     "packages/builder": {
       "name": "@rnrepo/builder",
@@ -64,11 +64,11 @@
     },
     "packages/expo-config-plugin": {
       "name": "@rnrepo/expo-config-plugin",
-      "version": "0.3.0-beta.3",
+      "version": "0.3.1",
       "dependencies": {
         "@expo/config-plugins": "*",
         "@expo/config-types": "*",
-        "@rnrepo/build-tools": "0.1.3-beta.0",
+        "@rnrepo/build-tools": "0.1.4",
       },
       "devDependencies": {
         "expo-module-scripts": "^5.0.7",

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.4] - 2026-05-20
 
 ### Changed
 - Resolve Gradle repositories once instead of per-package check for improved build performance (#337)

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.4] - 2026-05-20
+## [0.1.4] - 2026-05-21
 
 ### Changed
 - Resolve Gradle repositories once instead of per-package check for improved build performance (#337)

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/build-tools",
   "title": "RNRepo Prebuilds plugin",
-  "version": "0.1.3-beta.0",
+  "version": "0.1.4",
   "description": "RNRepo plugin for handling prebuilt binaries of iOS and Android libraries",
   "scripts": {
     "build": "./gradle-plugin/gradlew build --no-daemon -p gradle-plugin",

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] - 2026-05-20
+## [0.3.1] - 2026-05-21
 
 ### Changed
 - Bumped @rnrepo/build-tools dependency to 0.1.4 (#344)

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-05-20
+
+### Changed
+- Bumped @rnrepo/build-tools dependency to 0.1.4 (#344)
+
 ## [0.3.0-beta.3] - 2026-04-30
 
 ### Changed

--- a/packages/expo-config-plugin/package.json
+++ b/packages/expo-config-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/expo-config-plugin",
   "title": "RNRepo expo config plugin",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.1",
   "description": "Plugin for configuring RNRepo prebuilt packages in Expo projects",
   "sideEffects": false,
   "main": "build/withRNRepoPlugin.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/config-plugins": "*",
     "@expo/config-types": "*",
-    "@rnrepo/build-tools": "0.1.3-beta.0"
+    "@rnrepo/build-tools": "0.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"

--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -83,11 +83,6 @@ import Logo from './Logo.astro';
     >
       <div class="flex items-center gap-2 mb-4 md:mb-0">
         <Logo name="rnrepo" className="h-5 w-auto" />
-        <span
-          class="bg-rnrGrey-0 text-black px-1 rounded-sm text-[10px] font-bold"
-        >
-          BETA
-        </span>
       </div>
 
       <div class="flex space-x-6 mb-4 md:mb-0">

--- a/packages/website/src/components/GettingStarted.astro
+++ b/packages/website/src/components/GettingStarted.astro
@@ -122,27 +122,6 @@ const iOSPodfileCodeHtml = await codeToHtml(iOSPodfile, {
       >
         Getting Started
       </h2>
-
-      {/* Beta Disclaimer */}
-      <div
-        class="mb-6 p-4 bg-brandYellow-100/10 border border-brandYellow-100/30 rounded-sm flex gap-3 items-center"
-      >
-        <div class="flex-shrink-0">
-          <Info class="w-5 h-5 text-brandYellow-100" />
-        </div>
-        <div class="flex-1">
-          <p class="text-sm text-rnrGrey-30 leading-relaxed">
-            RNRepo is currently in
-            <strong class="text-brandYellow-100">Beta</strong>, please report any feedback or issues with your setup via our{' '}
-            <a
-              href="https://github.com/software-mansion/rnrepo"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-brandSeaBlue-100 hover:underline">GitHub</a
-            >.
-          </p>
-        </div>
-      </div>
     </div>
 
     <p class="text-lg text-rnrGrey-40 leading-relaxed mb-8">

--- a/packages/website/src/components/Navbar.astro
+++ b/packages/website/src/components/Navbar.astro
@@ -12,11 +12,6 @@ import { Github, Menu, X } from 'lucide-astro';
         <a href="/#" class="navbar-logo-link">
           <Logo name="rnrepo" className="h-8 w-auto" />
         </a>
-        <span
-          class="text-[10px] font-bold bg-rnrGrey-0 text-black px-1.5 py-0.5 rounded-sm self-start mt-1"
-        >
-          BETA
-        </span>
       </div>
 
       <div

--- a/packages/website/src/components/SupportedLibraries.astro
+++ b/packages/website/src/components/SupportedLibraries.astro
@@ -58,27 +58,6 @@ const supportedLibraryNames = await getSupportedLibraryNames();
       </p>
     </div>
 
-    {/* Beta Disclaimer */}
-    <div
-      class="mb-6 p-4 bg-brandYellow-100/10 border border-brandYellow-100/30 rounded-sm flex gap-3 items-center"
-    >
-      <div class="flex-shrink-0">
-        <Info class="w-5 h-5 text-brandYellow-100" />
-      </div>
-      <div class="flex-1">
-        <p class="text-sm text-rnrGrey-30 leading-relaxed">
-          RNRepo is currently in
-          <strong class="text-brandYellow-100">Beta</strong>, please report any feedback or issues with your setup via our{' '}
-          <a
-            href="https://github.com/software-mansion/rnrepo"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-brandSeaBlue-100 hover:underline">GitHub</a
-          >.
-        </p>
-      </div>
-    </div>
-
     {/* React Native Versions Card */}
     <div
       class="rounded-lg border border-rnrGrey-80 bg-surface/40 px-4 py-6 mb-8"


### PR DESCRIPTION
## 📝 Description

Bump versions before release:
- @rnrepo/build-tools@0.1.4
- @rnrepo/expo-config-plugin@0.3.1

And remove any `beta` labels in docs/website

## 🎯 Type of Change

- [x] 📚 Documentation update