### PR TITLE
Support react-native-tvos on iOS

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support react-native-tvos on iOS by stripping pre-release version suffixes (#345)
+
 ### Changed
 - Resolve Gradle repositories once instead of per-package check for improved build performance (#337)
 - Handle Xcode settings in both array and string formats (#330)

--- a/packages/build-tools/cocoapods-plugin/lib/pod_extractor.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/pod_extractor.rb
@@ -96,8 +96,11 @@ module CocoapodsRnrepo
 
         # Check if command succeeded
         if $?.success? && !result.empty? && result.match?(/^\d+\.\d+\.\d+/)
-          Logger.log "  ✓ Found React Native version: #{result}"
-          return result
+          # Strip non-core suffixes (e.g. react-native-tvos "0.83.2-0" → "0.83.2")
+          # so the version aligns with the prebuilt artifact naming.
+          core_version = strip_version_to_core(result)
+          Logger.log "  ✓ Found React Native version: #{core_version}"
+          return core_version
         else
           Logger.log "  ✗ Node.js command failed or returned invalid version: #{result}"
         end
@@ -107,6 +110,14 @@ module CocoapodsRnrepo
 
       Logger.log "  ⚠️  Could not detect React Native version"
       nil
+    end
+
+    # Trim a version string to its major.minor.patch core, dropping any pre-release
+    # or build suffix. Mirrors the Android plugin's stripVersionToCore so the
+    # detected RN version matches the prebuilt artifact naming on the server.
+    def self.strip_version_to_core(version)
+      match = version.match(/^\d+\.\d+\.\d+/)
+      match ? match[0] : version
     end
   end
 end


### PR DESCRIPTION
## 📝 Description

Ports the Android `stripVersionToCore` fix from #147 to the CocoaPods plugin. `react-native-tvos` versions like `0.83.2-0` were being passed through unchanged when building prebuilt artifact URLs, producing 404s on the rnrepo server (the published artifacts use the core form `rn0.83.2`). The CocoaPods side now trims the detected RN version to its `major.minor.patch` core, matching Android.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

Verified locally that the artifacts are downloaded correctly.

**Steps to reproduce:**
1. In an app whose `package.json` has `"react-native": "npm:react-native-tvos@0.83.2-0"`, run `pod install`.
2. **Before:** plugin attempts `…-rn0.83.2-0-…xcframework.zip` → 404, all packages fall back to source.
3. **After:** plugin requests `…-rn0.83.2-…xcframework.zip` → prebuilt frameworks are downloaded and cached.