### PR TITLE
Support global rnrepo.config.json on iOS

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Resolve Gradle repositories once instead of per-package check for improved build performance (#337)
 - Handle Xcode settings in both array and string formats (#330)
+- iOS CocoaPods more robust in resolving `rnrepo.config.json` (#346)
 
 ## [0.1.3-beta.0] - 2026-04-30
 

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -19,9 +19,34 @@ require_relative 'framework_cache'
 # +  rnrepo_post_install(installer)
 #
 
+# Walks up the directory tree looking for node_modules/react-native,
+# matching the behavior of the Android Gradle plugin's getReactNativeRoot.
+# Falls back to Node's resolver for non-standard layouts (e.g. monorepos
+# with hoisting disabled).
+def find_react_native_root(start_dir)
+  current = File.expand_path(start_dir)
+  loop do
+    if File.directory?(File.join(current, 'node_modules', 'react-native'))
+      return current
+    end
+    parent = File.dirname(current)
+    break if parent == current
+    current = parent
+  end
+
+  rn_package_path = `cd "#{start_dir}" && node --print "require.resolve('react-native/package.json')" 2>/dev/null`.strip
+  if !rn_package_path.empty? && File.exist?(rn_package_path)
+    return File.expand_path('../..', rn_package_path)
+  end
+
+  nil
+end
+
 # Helper method to load and parse rnrepo.config.json
 def load_rnrepo_config(workspace_root)
-  config_path = File.join(workspace_root, '..', 'rnrepo.config.json')
+  rn_root = find_react_native_root(workspace_root)
+  search_dir = rn_root || File.expand_path('..', workspace_root)
+  config_path = File.join(search_dir, 'rnrepo.config.json')
   CocoapodsRnrepo::Logger.log "Loading rnrepo.config.json from #{config_path}"
   return {} unless File.exist?(config_path)
 

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -1,5 +1,6 @@
 require 'cocoapods'
 require 'json'
+require 'shellwords'
 require_relative 'logger'
 require_relative 'pod_extractor'
 require_relative 'downloader'
@@ -34,9 +35,9 @@ def find_react_native_root(start_dir)
     current = parent
   end
 
-  rn_package_path = `cd "#{start_dir}" && node --print "require.resolve('react-native/package.json')" 2>/dev/null`.strip
+  rn_package_path = `cd #{Shellwords.escape(start_dir)} && node --print "require.resolve('react-native/package.json')" 2>/dev/null`.strip
   if !rn_package_path.empty? && File.exist?(rn_package_path)
-    return File.expand_path('../..', rn_package_path)
+    return File.expand_path('../..', File.dirname(rn_package_path))
   end
 
   nil


### PR DESCRIPTION
## 📝 Description

The iOS Cocoapods plugin loaded `rnrepo.config.json` from the directory one level above the Podfile (i.e. the package root). That works in a single-app project where the config sits next to the `ios/` folder, but in a monorepo where the config lives at the repo root (alongside hoisted `node_modules`), the file was never found and the `denyList` was silently ignored.

This change mirrors the Android Gradle plugin's `getReactNativeRoot`: walk up from the Podfile's directory looking for `node_modules/react-native`, with a `node require.resolve('react-native/package.json')` fallback for non-standard / non-hoisted layouts. For single-app projects, the resolved directory is the same as before, so existing setups are unaffected.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

Validated against a monorepo where the config lives at the repo root and the iOS app lives at `packages/apps/<App>/ios/`.

**Steps to reproduce:**
1. Set up a monorepo with `rnrepo.config.json` at the repo root and an iOS app under `packages/apps/<App>/ios/`. Populate `denyList.ios` with a few package names.
2. Run `pod install` in the iOS app directory.
3. Before this change: the config is not found and no pods are denied. After this change: the log shows `Loading rnrepo.config.json from <repo-root>/rnrepo.config.json` followed by `⊘ Denied from pre-builds (...)` listing the denied packages.