### PR TITLE
remove support for iOS in `react-native-permissions`

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -554,12 +554,6 @@
         "versionMatcher": "*",
         "publishedAfterDate": "2025-01-01"
       }
-    ],
-    "ios": [
-      {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
-      }
     ]
   },
   "@react-native-picker/picker": {


### PR DESCRIPTION


## 📝 Description




Remove iOS support for `react-native-permissions`

`react-native-permissions` requires all used permissions to be explicitly configured during `pod install`, which makes it impossible to prebuild and distribute all possible permission permutations.

Including all permission handlers by default is not a viable solution either, because iOS will crash if a permission is accessed without the corresponding usage description being defined in `Info.plist`.

This means we need to remove all iOS artifacts for `react-native-permissions` from Maven.

Example runtime crash:

```text
This app has crashed because it attempted to access privacy-sensitive data without a usage description.
```

#347

## 🎯 Type of Change

- [x] 🧩 New library support