### PR TITLE
exclude @rnrepo libs from 7 days npm limit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7d
+min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7
+min-release-age=4


### PR DESCRIPTION
## 📝 Description

7d is not a vaild option (but was mentioned in [article](https://www.armorcode.com/blog/defending-against-npm-supply-chain-attacks-a-practical-guide)). just '7' is still refering to elapsed days, so no functional changes here. This caused issues in packages publishing:
- https://github.com/software-mansion/rnrepo/actions/runs/26230821967/job/77190410179

docs: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)