### PR TITLE
fix: resolve worklets framework module map

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Resolve worklets framework module map (#352)
+
 ## [0.1.4] - 2026-05-21
 
 ### Added

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -509,8 +509,7 @@ def rnrepo_post_install(installer_context)
         raise "RNWorklets not found in podfile, add react-native-worklets to denyList."
       end
       worklets_framework_name = find_prebuilt_framework_name(worklets_pod)
-      worklets_module_map_path = "$(PODS_XCFRAMEWORKS_BUILD_DIR)/RNWorklets/#{worklets_framework_name}/Modules/module.modulemap"
-      module_map = "-fmodule-map-file=\"#{worklets_module_map_path}\""
+      module_map = "-fmodule-map-file=\"$(PODS_XCFRAMEWORKS_BUILD_DIR)/RNWorklets/#{worklets_framework_name}/Modules/module.modulemap\""
 
       target.build_configurations.each do |config|
         build_settings = config.build_settings
@@ -529,3 +528,4 @@ def rnrepo_post_install(installer_context)
     end
   end
 end
+

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -71,6 +71,29 @@ def is_version_at_least(current_version, minimum_version)
   Gem::Version.new(current_core) >= Gem::Version.new(minimum_version)
 end
 
+def find_framework_name_in_xcframework(xcframework_path)
+  framework_path =
+    Dir.glob(File.join(xcframework_path, '*', '*.framework')).find do |path|
+      File.directory?(path)
+    end
+
+  File.basename(framework_path) if framework_path
+end
+
+def find_prebuilt_framework_name(pod_info)
+  cache_dir = File.join(pod_info[:package_root], '.rnrepo-cache')
+  current_xcframeworks = Dir.glob(File.join(cache_dir, 'Current', '*.xcframework')).sort
+  fallback_xcframeworks = Dir.glob(File.join(cache_dir, '*', '*.xcframework')).sort
+  xcframework_paths = (current_xcframeworks + fallback_xcframeworks).uniq
+
+  framework_name =
+    xcframework_paths
+      .map { |xcframework_path| find_framework_name_in_xcframework(xcframework_path) }
+      .find { |name| !name.nil? }
+
+  framework_name || "#{pod_info[:name]}.framework"
+end
+
 def rnrepo_pre_install(installer_context)
   # Check if plugin is disabled via environment variable
   if ENV['DISABLE_RNREPO']
@@ -485,7 +508,9 @@ def rnrepo_post_install(installer_context)
       if worklets_root == nil
         raise "RNWorklets not found in podfile, add react-native-worklets to denyList."
       end
-      module_map = "-fmodule-map-file=\"$(PODS_XCFRAMEWORKS_BUILD_DIR)/RNWorklets/RNWorklets.framework/Modules/module.modulemap\""
+      worklets_framework_name = find_prebuilt_framework_name(worklets_pod)
+      worklets_module_map_path = "$(PODS_XCFRAMEWORKS_BUILD_DIR)/RNWorklets/#{worklets_framework_name}/Modules/module.modulemap"
+      module_map = "-fmodule-map-file=\"#{worklets_module_map_path}\""
 
       target.build_configurations.each do |config|
         build_settings = config.build_settings
@@ -504,4 +529,3 @@ def rnrepo_post_install(installer_context)
     end
   end
 end
-


### PR DESCRIPTION
## 📝 Description

Fixes #351.

The CocoaPods post-install hook currently injects an ExpoModulesCore module map path that assumes the prebuilt RNWorklets framework is named `RNWorklets.framework`. `react-native-worklets` packages the inner framework as `worklets.framework`, so the generated path points to a module map that does not exist.

This resolves the framework name from the cached `.xcframework` contents and uses that name when building the `-fmodule-map-file` flag. If the cached framework cannot be inspected, it falls back to the previous pod-name based path.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- `ruby -c packages/build-tools/cocoapods-plugin/lib/plugin.rb`
- Ran a Ruby helper check with temporary `.rnrepo-cache` directories verifying:
  - `worklets.xcframework/.../worklets.framework` resolves to `worklets.framework`
  - an xcframework without an inner framework directory falls back to `RNWorklets.framework`

**Steps to reproduce:**
1. Use RNRepo with Expo SDK 55+ and prebuilt `react-native-worklets`.
2. Run `pod install` and build iOS.
3. ExpoModulesCore should receive the module map flag pointing at the actual framework name inside the RNWorklets XCFramework intermediate.