### PR TITLE
Fix Reanimated 4.4 worklets setup

### DIFF
--- a/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
+++ b/postInstallScripts/react-native-reanimated/react-native-reanimated.ts
@@ -3,7 +3,11 @@ import semver from 'semver';
 
 const COMPATIBILITY_MATRIX = [
   {
-    reanimated: '>=4.3.0',
+    reanimated: '>=4.4.0',
+    worklets: '0.9.1'
+  },
+  {
+    reanimated: '>=4.3.0 <4.4.0',
     worklets: '0.8.1'
   },
 ];


### PR DESCRIPTION
## 📝 Description

Fixes the Reanimated post-install compatibility matrix for `react-native-reanimated@4.4.0`.

Reanimated `4.4.0` requires `react-native-worklets@0.9.x` or newer. The current RNRepo post-install script still installs `react-native-worklets@0.8.1` for all `react-native-reanimated >=4.3.0`, which makes the builder fail during `pod install` with `[Reanimated] Failed to validate worklets version`.

This updates the matrix so:

- `react-native-reanimated >=4.4.0` installs `react-native-worklets@0.9.1`
- `react-native-reanimated >=4.3.0 <4.4.0` keeps using `react-native-worklets@0.8.1`

This should unblock the failed Reanimated `4.4.0` prebuild jobs, including `react-native-reanimated@4.4.0` with React Native `0.85.3`.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

Ran TypeScript lint:

```bash
bun run lint-ts
```

Ran existing scheduler/npm tests:

```bash
bun test packages/scheduler/src/npm.test.ts packages/scheduler/src/scheduler.test.ts
```

Verified the actual iOS builder locally:

```bash
bun run packages/builder/build-library-ios.ts -- react-native-reanimated 4.4.0 0.85.3 /tmp/rnrepo-reanimated-verify
```

The local builder installed `react-native-worklets@0.9.1`, completed `pod install`, and successfully produced both artifacts:

- `react-native-reanimated-4.4.0-rn0.85.3-release.xcframework.zip`
- `react-native-reanimated-4.4.0-rn0.85.3-debug.xcframework.zip`