### PR TITLE
fix rngh patch for 2.25.0 and +3.0.0

### DIFF
--- a/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
+++ b/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
@@ -25,19 +25,22 @@ export default async function postInstallSetup(): Promise<void> {
     const rnVersion = await getPackageVersion('react-native');
     console.log(`Detected React Native version: ${rnVersion}`);
     const { reanimatedVersion, workletsVersion } = getReanimatedAndWorkletsVersion(rnVersion);
+    const gestureHandlerVersion = await getPackageVersion('react-native-gesture-handler');
     // Support RN-GH only with reanimated
     await $`bun install react-native-reanimated@${reanimatedVersion} --save-exact`.quiet();
     console.log(`✓ Installed react-native-reanimated@${reanimatedVersion}`);
     await $`bun install react-native-worklets@${workletsVersion} --save-exact`.quiet();
     console.log(`✓ Installed react-native-worklets@${workletsVersion}`);
-    // Patch react-native-gesture-handler to avoid issues with react-native-svg
-    await $`bun install react-native-svg`.quiet();
-    console.log('✓ Installed react-native-svg');
-    const patchPath = __dirname + '/react-native-gesture-handler.patch';
-    const packagePath = './node_modules/react-native-gesture-handler';
-    await $`/usr/bin/patch -p1 -i ${patchPath}`.cwd(packagePath).quiet();
-    console.log('✓ Patched react-native-gesture-handler for SVG compatibility');
-    
+    if (semver.gte(gestureHandlerVersion, '2.25.0')) {
+        // Patch react-native-gesture-handler to avoid issues with react-native-svg 
+        // svg was introduced in rngh@2.25.0
+        await $`bun install react-native-svg`.quiet();
+        console.log('✓ Installed react-native-svg');
+        const patchPath = getPatchFile(gestureHandlerVersion);
+        const packagePath = './node_modules/react-native-gesture-handler';
+        await $`/usr/bin/patch -p1 -i ${patchPath}`.cwd(packagePath).quiet();
+        console.log('✓ Patched react-native-gesture-handler for SVG compatibility');
+    }
     console.log(`✓ Post-install setup for react-native-gesture-handler completed.`);
 };
 
@@ -58,6 +61,17 @@ function getReanimatedAndWorkletsVersion(rnVersion: string): { reanimatedVersion
         throw new Error(`Unsupported React Native version: ${rnVersion}. Please check the compatibility matrix.`);
     }
     return { reanimatedVersion: config.reanimated, workletsVersion: config.worklets };
+}
+
+function getPatchFile(gestureHandlerVersion: string): string {
+    if (semver.gte(gestureHandlerVersion, '3.0.0')) {
+        return __dirname + '/react-native-gesture-handler_3.0.0.patch';
+    } else if (gestureHandlerVersion == '2.25.0') {
+        return __dirname + '/react-native-gesture-handler_2.25.0.patch';
+    } else {
+        // >=2.26.0, <3.0.0 
+        return __dirname + '/react-native-gesture-handler.patch';
+    }
 }
 
 try {

--- a/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler_2.25.0.patch
+++ b/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler_2.25.0.patch
@@ -1,0 +1,251 @@
+From fc5a5f4a115313921024f675fc4a3b1e0661268e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rados=C5=82aw=20Rolka?= <radoslaw.rolka@gmail.com>
+Date: Mon, 8 Jun 2026 15:05:57 +0200
+Subject: [PATCH] [PATCH] react-native-geture-handler patch for SVG
+
+react-native-svg no longer changes the RNGH's sourceSets
+---
+ android/build.gradle                          |  6 +-
+ .../gesturehandler/RNSVGHitTester.kt          | 13 ----
+ .../gesturehandler/RNSVGHitTester.kt          | 61 ++-----------------
+ .../svg/RNSVGHitTesterHelper.kt               | 17 ++++++
+ .../gesturehandler/svg/SvgHitTester.kt        |  8 +++
+ .../gesturehandler/svg/SvgHitTesterImpl.kt    | 57 +++++++++++++++++
+ .../gesturehandler/svg/SvgHitTesterNoOp.kt    |  9 +++
+ 7 files changed, 96 insertions(+), 75 deletions(-)
+ delete mode 100644 android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+
+diff --git a/android/build.gradle b/android/build.gradle
+index 99475ac..b074383 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -184,11 +184,7 @@ android {
+                 srcDirs += 'noreanimated/src/main/java'
+             }
+ 
+-            if (shouldUseCommonInterfaceFromRNSVG()) {
+-                srcDirs += 'svg/src/main/java'
+-            } else {
+-                srcDirs += 'nosvg/src/main/java'
+-            }
++            srcDirs += 'svg/src/main/java'
+ 
+             if (isNewArchitectureEnabled()) {
+                 srcDirs += 'fabric/src/main/java'
+diff --git a/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt b/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+deleted file mode 100644
+index 6c4aedd..0000000
+--- a/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
++++ /dev/null
+@@ -1,13 +0,0 @@
+-package com.swmansion.gesturehandler
+-
+-import android.view.View
+-
+-class RNSVGHitTester {
+-  companion object {
+-    @Suppress("UNUSED_PARAMETER")
+-    fun isSvgElement(view: Any) = false
+-
+-    @Suppress("UNUSED_PARAMETER")
+-    fun hitTest(view: View, posX: Float, posY: Float) = false
+-  }
+-}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+index 4b4e94a..12ca522 100644
+--- a/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+@@ -1,67 +1,14 @@
+ package com.swmansion.gesturehandler
+ 
+ import android.view.View
+-import androidx.core.view.children
+-import com.horcrux.svg.SvgView
+-import com.horcrux.svg.VirtualView
++import com.swmansion.gesturehandler.svg.RNSVGHitTesterHelper
+ 
+ class RNSVGHitTester {
+   companion object {
+-    private fun getRootSvgView(view: View): SvgView {
+-      var rootSvgView: SvgView
++    private val delegate by lazy { RNSVGHitTesterHelper.provide() }
+ 
+-      rootSvgView = if (view is VirtualView) {
+-        view.svgView!!
+-      } else {
+-        view as SvgView
+-      }
++    fun isSvgElement(view: Any): Boolean = delegate.isSvgElement(view)
+ 
+-      while (isSvgElement(rootSvgView.parent)) {
+-        rootSvgView = if (rootSvgView.parent is VirtualView) {
+-          (rootSvgView.parent as VirtualView).svgView!!
+-        } else {
+-          rootSvgView.parent as SvgView
+-        }
+-      }
+-
+-      return rootSvgView
+-    }
+-
+-    fun isSvgElement(view: Any): Boolean {
+-      return (view is VirtualView || view is SvgView)
+-    }
+-
+-    fun hitTest(view: View, posX: Float, posY: Float): Boolean {
+-      val rootSvgView = getRootSvgView(view)
+-      val viewLocation = intArrayOf(0, 0)
+-      val rootLocation = intArrayOf(0, 0)
+-
+-      view.getLocationOnScreen(viewLocation)
+-      rootSvgView.getLocationOnScreen(rootLocation)
+-
+-      // convert View-relative coordinates into SvgView-relative coordinates
+-      val rootX = posX + viewLocation[0] - rootLocation[0]
+-      val rootY = posY + viewLocation[1] - rootLocation[1]
+-
+-      val pressedId = rootSvgView.reactTagForTouch(rootX, rootY)
+-      val hasBeenPressed = view.id == pressedId
+-
+-      // hitTest(view, ...) should only be called after isSvgElement(view) returns true
+-      // Consequently, `view` will always be either SvgView or VirtualView
+-
+-      val pressIsInBounds =
+-        posX in 0.0..view.width.toDouble() &&
+-          posY in 0.0..view.height.toDouble()
+-
+-      if (view is SvgView) {
+-        val childrenIds = view.children.map { it.id }
+-
+-        val hasChildBeenPressed = pressedId in childrenIds
+-
+-        return (hasBeenPressed || hasChildBeenPressed) && pressIsInBounds
+-      }
+-
+-      return hasBeenPressed && pressIsInBounds
+-    }
++    fun hitTest(view: View, posX: Float, posY: Float): Boolean = delegate.hitTest(view, posX, posY)
+   }
+ }
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+new file mode 100644
+index 0000000..b42980a
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+@@ -0,0 +1,17 @@
++package com.swmansion.gesturehandler.svg
++
++internal object RNSVGHitTesterHelper {
++  private const val SVG_VIEW_CLASS = "com.horcrux.svg.SvgView"
++  private const val IMPLEMENTATION_CLASS =
++    "com.swmansion.gesturehandler.svg.SvgHitTesterImpl"
++
++  fun provide(): SvgHitTester = try {
++    Class.forName(SVG_VIEW_CLASS)
++    val implementationClass = Class.forName(IMPLEMENTATION_CLASS)
++    implementationClass.getDeclaredConstructor().newInstance() as SvgHitTester
++  } catch (_: ClassNotFoundException) {
++    SvgHitTesterNoOp
++  } catch (_: ReflectiveOperationException) {
++    SvgHitTesterNoOp
++  }
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+new file mode 100644
+index 0000000..99da5d8
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+@@ -0,0 +1,8 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++
++internal interface SvgHitTester {
++  fun isSvgElement(view: Any): Boolean
++  fun hitTest(view: View, posX: Float, posY: Float): Boolean
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+new file mode 100644
+index 0000000..79b1c5c
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+@@ -0,0 +1,57 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++import androidx.core.view.children
++import com.horcrux.svg.SvgView
++import com.horcrux.svg.VirtualView
++
++internal class SvgHitTesterImpl : SvgHitTester {
++  private fun getRootSvgView(view: View): SvgView {
++    var rootSvgView: SvgView =
++      if (view is VirtualView) {
++        view.svgView!!
++      } else {
++        view as SvgView
++      }
++
++    while (isSvgElement(rootSvgView.parent)) {
++      rootSvgView =
++        if (rootSvgView.parent is VirtualView) {
++          (rootSvgView.parent as VirtualView).svgView!!
++        } else {
++          rootSvgView.parent as SvgView
++        }
++    }
++
++    return rootSvgView
++  }
++
++  override fun isSvgElement(view: Any): Boolean = (view is VirtualView || view is SvgView)
++
++  override fun hitTest(view: View, posX: Float, posY: Float): Boolean {
++    val rootSvgView = getRootSvgView(view)
++    val viewLocation = intArrayOf(0, 0)
++    val rootLocation = intArrayOf(0, 0)
++
++    view.getLocationOnScreen(viewLocation)
++    rootSvgView.getLocationOnScreen(rootLocation)
++
++    val rootX = posX + viewLocation[0] - rootLocation[0]
++    val rootY = posY + viewLocation[1] - rootLocation[1]
++
++    val pressedId = rootSvgView.reactTagForTouch(rootX, rootY)
++    val hasBeenPressed = view.id == pressedId
++
++    val pressIsInBounds =
++      posX in 0.0..view.width.toDouble() &&
++        posY in 0.0..view.height.toDouble()
++
++    if (view is SvgView) {
++      val childrenIds = view.children.map { it.id }
++      val hasChildBeenPressed = pressedId in childrenIds
++      return (hasBeenPressed || hasChildBeenPressed) && pressIsInBounds
++    }
++
++    return hasBeenPressed && pressIsInBounds
++  }
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+new file mode 100644
+index 0000000..881754f
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+@@ -0,0 +1,9 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++
++internal object SvgHitTesterNoOp : SvgHitTester {
++  override fun isSvgElement(view: Any) = false
++
++  override fun hitTest(view: View, posX: Float, posY: Float) = false
++}
+-- 
+2.49.0
+

--- a/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler_3.0.0.patch
+++ b/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler_3.0.0.patch
@@ -1,0 +1,248 @@
+From d24f8de6e6a223e9d4cda20437390465c6b626ea Mon Sep 17 00:00:00 2001
+From: Radoslaw Rolka <radoslaw.rolka@gmail.com>
+Date: Mon, 8 Jun 2026 14:24:26 +0200
+Subject: [PATCH] [PATCH] react-native-geture-handler patch for SVG
+
+react-native-svg no longer changes the RNGH's sourceSets
+---
+ android/build.gradle                          |  6 +-
+ .../gesturehandler/RNSVGHitTester.kt          | 13 ----
+ .../gesturehandler/RNSVGHitTester.kt          | 59 ++-----------------
+ .../svg/RNSVGHitTesterHelper.kt               | 17 ++++++
+ .../gesturehandler/svg/SvgHitTester.kt        |  8 +++
+ .../gesturehandler/svg/SvgHitTesterImpl.kt    | 57 ++++++++++++++++++
+ .../gesturehandler/svg/SvgHitTesterNoOp.kt    |  9 +++
+ 7 files changed, 96 insertions(+), 73 deletions(-)
+ delete mode 100644 android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+ create mode 100644 android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+
+diff --git a/android/build.gradle b/android/build.gradle
+index e6bcad6..b4a60bc 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -189,11 +189,7 @@ android {
+                 srcDirs += 'noreanimated/src/main/java'
+             }
+
+-            if (shouldUseCommonInterfaceFromRNSVG()) {
+-                srcDirs += 'svg/src/main/java'
+-            } else {
+-                srcDirs += 'nosvg/src/main/java'
+-            }
++            srcDirs += 'svg/src/main/java'
+         }
+     }
+
+diff --git a/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt b/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+deleted file mode 100644
+index 6c4aedd..0000000
+--- a/android/nosvg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
++++ /dev/null
+@@ -1,13 +0,0 @@
+-package com.swmansion.gesturehandler
+-
+-import android.view.View
+-
+-class RNSVGHitTester {
+-  companion object {
+-    @Suppress("UNUSED_PARAMETER")
+-    fun isSvgElement(view: Any) = false
+-
+-    @Suppress("UNUSED_PARAMETER")
+-    fun hitTest(view: View, posX: Float, posY: Float) = false
+-  }
+-}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+index 2a4f600..12ca522 100644
+--- a/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/RNSVGHitTester.kt
+@@ -1,65 +1,14 @@
+ package com.swmansion.gesturehandler
+
+ import android.view.View
+-import androidx.core.view.children
+-import com.horcrux.svg.SvgView
+-import com.horcrux.svg.VirtualView
++import com.swmansion.gesturehandler.svg.RNSVGHitTesterHelper
+
+ class RNSVGHitTester {
+   companion object {
+-    private fun getRootSvgView(view: View): SvgView {
+-      var rootSvgView: SvgView
++    private val delegate by lazy { RNSVGHitTesterHelper.provide() }
+
+-      rootSvgView = if (view is VirtualView) {
+-        view.svgView!!
+-      } else {
+-        view as SvgView
+-      }
++    fun isSvgElement(view: Any): Boolean = delegate.isSvgElement(view)
+
+-      while (isSvgElement(rootSvgView.parent)) {
+-        rootSvgView = if (rootSvgView.parent is VirtualView) {
+-          (rootSvgView.parent as VirtualView).svgView!!
+-        } else {
+-          rootSvgView.parent as SvgView
+-        }
+-      }
+-
+-      return rootSvgView
+-    }
+-
+-    fun isSvgElement(view: Any): Boolean = (view is VirtualView || view is SvgView)
+-
+-    fun hitTest(view: View, posX: Float, posY: Float): Boolean {
+-      val rootSvgView = getRootSvgView(view)
+-      val viewLocation = intArrayOf(0, 0)
+-      val rootLocation = intArrayOf(0, 0)
+-
+-      view.getLocationOnScreen(viewLocation)
+-      rootSvgView.getLocationOnScreen(rootLocation)
+-
+-      // convert View-relative coordinates into SvgView-relative coordinates
+-      val rootX = posX + viewLocation[0] - rootLocation[0]
+-      val rootY = posY + viewLocation[1] - rootLocation[1]
+-
+-      val pressedId = rootSvgView.reactTagForTouch(rootX, rootY)
+-      val hasBeenPressed = view.id == pressedId
+-
+-      // hitTest(view, ...) should only be called after isSvgElement(view) returns true
+-      // Consequently, `view` will always be either SvgView or VirtualView
+-
+-      val pressIsInBounds =
+-        posX in 0.0..view.width.toDouble() &&
+-          posY in 0.0..view.height.toDouble()
+-
+-      if (view is SvgView) {
+-        val childrenIds = view.children.map { it.id }
+-
+-        val hasChildBeenPressed = pressedId in childrenIds
+-
+-        return (hasBeenPressed || hasChildBeenPressed) && pressIsInBounds
+-      }
+-
+-      return hasBeenPressed && pressIsInBounds
+-    }
++    fun hitTest(view: View, posX: Float, posY: Float): Boolean = delegate.hitTest(view, posX, posY)
+   }
+ }
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+new file mode 100644
+index 0000000..b42980a
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/RNSVGHitTesterHelper.kt
+@@ -0,0 +1,17 @@
++package com.swmansion.gesturehandler.svg
++
++internal object RNSVGHitTesterHelper {
++  private const val SVG_VIEW_CLASS = "com.horcrux.svg.SvgView"
++  private const val IMPLEMENTATION_CLASS =
++    "com.swmansion.gesturehandler.svg.SvgHitTesterImpl"
++
++  fun provide(): SvgHitTester = try {
++    Class.forName(SVG_VIEW_CLASS)
++    val implementationClass = Class.forName(IMPLEMENTATION_CLASS)
++    implementationClass.getDeclaredConstructor().newInstance() as SvgHitTester
++  } catch (_: ClassNotFoundException) {
++    SvgHitTesterNoOp
++  } catch (_: ReflectiveOperationException) {
++    SvgHitTesterNoOp
++  }
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+new file mode 100644
+index 0000000..99da5d8
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTester.kt
+@@ -0,0 +1,8 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++
++internal interface SvgHitTester {
++  fun isSvgElement(view: Any): Boolean
++  fun hitTest(view: View, posX: Float, posY: Float): Boolean
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+new file mode 100644
+index 0000000..79b1c5c
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterImpl.kt
+@@ -0,0 +1,57 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++import androidx.core.view.children
++import com.horcrux.svg.SvgView
++import com.horcrux.svg.VirtualView
++
++internal class SvgHitTesterImpl : SvgHitTester {
++  private fun getRootSvgView(view: View): SvgView {
++    var rootSvgView: SvgView =
++      if (view is VirtualView) {
++        view.svgView!!
++      } else {
++        view as SvgView
++      }
++
++    while (isSvgElement(rootSvgView.parent)) {
++      rootSvgView =
++        if (rootSvgView.parent is VirtualView) {
++          (rootSvgView.parent as VirtualView).svgView!!
++        } else {
++          rootSvgView.parent as SvgView
++        }
++    }
++
++    return rootSvgView
++  }
++
++  override fun isSvgElement(view: Any): Boolean = (view is VirtualView || view is SvgView)
++
++  override fun hitTest(view: View, posX: Float, posY: Float): Boolean {
++    val rootSvgView = getRootSvgView(view)
++    val viewLocation = intArrayOf(0, 0)
++    val rootLocation = intArrayOf(0, 0)
++
++    view.getLocationOnScreen(viewLocation)
++    rootSvgView.getLocationOnScreen(rootLocation)
++
++    val rootX = posX + viewLocation[0] - rootLocation[0]
++    val rootY = posY + viewLocation[1] - rootLocation[1]
++
++    val pressedId = rootSvgView.reactTagForTouch(rootX, rootY)
++    val hasBeenPressed = view.id == pressedId
++
++    val pressIsInBounds =
++      posX in 0.0..view.width.toDouble() &&
++        posY in 0.0..view.height.toDouble()
++
++    if (view is SvgView) {
++      val childrenIds = view.children.map { it.id }
++      val hasChildBeenPressed = pressedId in childrenIds
++      return (hasBeenPressed || hasChildBeenPressed) && pressIsInBounds
++    }
++
++    return hasBeenPressed && pressIsInBounds
++  }
++}
+diff --git a/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+new file mode 100644
+index 0000000..881754f
+--- /dev/null
++++ b/android/svg/src/main/java/com/swmansion/gesturehandler/svg/SvgHitTesterNoOp.kt
+@@ -0,0 +1,9 @@
++package com.swmansion.gesturehandler.svg
++
++import android.view.View
++
++internal object SvgHitTesterNoOp : SvgHitTester {
++  override fun isSvgElement(view: Any) = false
++
++  override fun hitTest(view: View, posX: Float, posY: Float) = false
++}
+--
+2.50.1 (Apple Git-155)


### PR DESCRIPTION
## 📝 Description

2.25.0 and +3.0.0 builds failed due to patch applying failures. Only diffs in .patch files are single lines:
```
$ diff react-native-gesture-handler.patch react-native-gesture-handler_2.25.0.patch

62c62
< @@ -1,65 +1,14 @@
---
> @@ -1,67 +1,14 @@
95c95,97
< -    fun isSvgElement(view: Any): Boolean = (view is VirtualView || view is SvgView)
---
> -    fun isSvgElement(view: Any): Boolean {
> -      return (view is VirtualView || view is SvgView)
> -    }
```
and
```
$ diff react-native-gesture-handler.patch react-native-gesture-handler_3.0.0.patch

29c29
<
---
>
36,38c36,38
<
<              if (isNewArchitectureEnabled()) {
<                  srcDirs += 'fabric/src/main/java'
---
>          }
>      }
>

```
