### PR TITLE
Detect debug configuration using GCC preprocessor definitions

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Resolve worklets framework module map (#352)
+- Detect debug configuration using GCC preprocessor definitions (#367)
 
 ## [0.1.4] - 2026-05-21
 

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -444,14 +444,15 @@ def rnrepo_post_install(installer_context)
       CACHE_DIR="${PODS_TARGET_SRCROOT}/.rnrepo-cache"
       CURRENT_LINK="${CACHE_DIR}/Current"
 
-      # Select the appropriate configuration
-      if [ "$CONFIGURATION" == "Debug" ]; then
+      # Select the appropriate configuration based on whether this is a
+      # debuggable build. Matching on the $CONFIGURATION name is unreliable
+      # because projects can define custom configuration names (e.g.
+      # "Staging", "QA") that are neither "Debug" nor "Release". Instead we
+      # detect the DEBUG=1 preprocessor definition, which mirrors how React
+      # Native core selects its prebuilt configuration.
+      TARGET_DIR="Release"
+      if echo "$GCC_PREPROCESSOR_DEFINITIONS" | grep -q "DEBUG=1"; then
         TARGET_DIR="Debug"
-      elif [ "$CONFIGURATION" == "Release" ]; then
-        TARGET_DIR="Release"
-      else
-        echo "warning: Unknown configuration '$CONFIGURATION', defaulting to Release"
-        TARGET_DIR="Release"
       fi
       echo "RNREPO: Switching to ${TARGET_DIR} configuration"
 


### PR DESCRIPTION
## 📝 Description

Switches the build configuration detection mechanism from matching the `$CONFIGURATION` name to checking `$GCC_PREPROCESSOR_DEFINITIONS` for `DEBUG=1`.

Matching solely on `$CONFIGURATION == "Debug"` is unreliable because projects often define custom build configurations (e.g., "Staging", "QA") that do not explicitly use the names "Debug" or "Release", leading to incorrect fallbacks.

This change aligns the plugin's behavior with React Native core, which uses the `DEBUG=1` definition to select its prebuilt configuration.
link: https://github.com/facebook/react-native/blob/main/packages/react-native/React-Core-prebuilt.podspec#L61

Closes #361 

## 🧪 Testing

```
$ npx expo run:ios --configuration Release
...
$ realpath node_modules/react-native-worklets/.rnrepo-cache/Current/dummy.h
.../node_modules/react-native-worklets/.rnrepo-cache/Release/dummy.h

$ npx expo run:ios --configuration Debug
...
$ realpath node_modules/react-native-worklets/.rnrepo-cache/Current/dummy.h
.../node_modules/react-native-worklets/.rnrepo-cache/Debug/dummy.h

$ npx expo run:ios --configuration NOTEXIST
...
$ realpath node_modules/react-native-worklets/.rnrepo-cache/Current/dummy.h
.../node_modules/react-native-worklets/.rnrepo-cache/Release/dummy.h

$ npx expo run:ios --configuration Custom.de
...
$ realpath node_modules/react-native-worklets/.rnrepo-cache/Current/dummy.h
.../node_modules/react-native-worklets/.rnrepo-cache/Debug/dummy.h

$ npx expo run:ios --configuration Custom.re
...
$ realpath node_modules/react-native-worklets/.rnrepo-cache/Current/dummy.h
.../node_modules/react-native-worklets/.rnrepo-cache/Release/dummy.h
```
