### PR TITLE
Codegen autolinking injection

### DIFF
--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
@@ -95,7 +95,7 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
                 if (hasLib) {
                     foundAnyLib = true
                 } else {
-                    project.logger.warn("RNRepo: No $currentBuildType codegen library found for $abi in $moduleName")
+                    project.logger.info("RNRepo: No $currentBuildType codegen library found for $abi in $moduleName")
                 }
             }
 
@@ -152,20 +152,24 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
     @Suppress("UNCHECKED_CAST")
     private fun transformAutolinkingConfig(cmakeListsByCodegenName: Map<String, File>) {
         val outputFile = transformedAutolinkFile.get().asFile
-        outputFile.parentFile.mkdirs()
+        // Remove any stale output from a previous run. The presence of this file is the signal that
+        // tells PrebuildsPlugin to redirect React Native's autolinking input here, so it must exist
+        // only when we actually rewrote cmake paths below. In every early-return case we leave it
+        // absent so React Native keeps using its own, untouched autolinking.json.
+        if (outputFile.exists()) outputFile.delete()
 
         val inputFile = autolinkInputFile.orNull?.asFile
         if (inputFile == null || !inputFile.exists()) {
             project.logger.warn(
-                "RNRepo: autolinking.json not found, skipping cmake path injection — prebuilt codegen will be ignored, build time will be longer",
+                "RNRepo: autolinking.json not found, skipping cmake path injection — React Native will use its own " +
+                    "autolinking config and prebuilt codegen will be ignored, so the build will be slower",
             )
-            // Always produce the declared output so downstream tasks don't fail on a missing input
-            outputFile.writeText("{\"dependencies\":{}}")
             return
         }
 
         if (cmakeListsByCodegenName.isEmpty()) {
-            inputFile.copyTo(outputFile, overwrite = true)
+            // Nothing to redirect (e.g. every codegen package was header-only); leave React Native on
+            // its own autolinking.json rather than handing it an identical copy.
             return
         }
 
@@ -193,6 +197,7 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
             )
         }
 
+        outputFile.parentFile.mkdirs()
         outputFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
         project.logger.lifecycle("RNRepo: Wrote transformed autolinking.json (${rewrittenLibraries.size} cmake paths redirected)")
     }

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
@@ -1,12 +1,19 @@
 package org.rnrepo.tools.prebuilds
 
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -20,19 +27,26 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
     @get:Input
     abstract val buildType: Property<String>
 
+    @get:InputFile
+    @get:Optional
+    abstract val autolinkInputFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val transformedAutolinkFile: RegularFileProperty
+
     @TaskAction
     fun execute() {
         val outDir = outputDir.get().asFile
         if (outDir.exists()) outDir.deleteRecursively()
         outDir.mkdirs()
 
-        val codegenListFile = File(outDir, "codegen_libs.txt")
         val abis = listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
-        val sb = StringBuilder()
+        val cmakeListsByCodegenName = mutableMapOf<String, File>()
 
         codegenConfiguration.get().resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
             val moduleName = artifact.name
-            val extractionDir = File(project.buildDir, "intermediates/rnrepo/$moduleName")
+            // Extract inside outputDir so cmake file's CMAKE_CURRENT_LIST_DIR paths are self-contained
+            val extractionDir = File(outDir, "artifacts/$moduleName")
 
             // 1. Unpack AAR
             project.copy {
@@ -46,63 +60,99 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
                     if (it.exists()) it else File(extractionDir, "assets/meta/codegen_name.txt")
                 }
 
-            if (metaFile.exists()) {
-                val codegenName = metaFile.readText().trim()
-                val currentBuildType = buildType.get()
-                var foundAnyLib = false
+            if (!metaFile.exists()) {
+                throw GradleException("RNRepo: Codegen prebuilt $moduleName does not contain codegen_name.txt")
+            }
 
-                // 3. Extract static libraries (.a files) for each ABI from the correct build variant
-                abis.forEach { abi ->
-                    // Try variant-specific path first (new format)
-                    val variantStaticLib =
-                        project
-                            .fileTree(extractionDir) {
-                                it.include("**/assets/$currentBuildType/$abi/**/libreact_codegen_$codegenName.a")
-                            }.firstOrNull()
+            val codegenName = metaFile.readText().trim()
+            // release builds use RelWithDebInfo cmake type — artifacts are stored under relwithdebinfo/
+            val currentBuildType = if (buildType.get() == "release") "relwithdebinfo" else buildType.get()
+            var foundAnyLib = false
 
-                    if (variantStaticLib != null) {
-                        val abiDest = File(outDir, abi)
-                        abiDest.mkdirs()
-                        project.copy {
-                            it.from(variantStaticLib)
-                            it.into(abiDest)
-                        }
-                        foundAnyLib = true
-                        project.logger.lifecycle("RNRepo: Extracted $currentBuildType codegen library for $abi from $moduleName")
-                    } else {
-                        project.logger.warn("RNRepo: No $currentBuildType codegen library found for $abi in $moduleName")
-                    }
-                }
+            abis.forEach { abi ->
+                val hasLib =
+                    project
+                        .fileTree(extractionDir) {
+                            it.include("**/assets/$currentBuildType/$abi/**/libreact_codegen_$codegenName.a")
+                        }.firstOrNull() != null
 
-                // 4. Extract Headers from assets/headers
-                if (foundAnyLib) {
-                    val headersDir = File(outDir, "headers/$codegenName")
-                    headersDir.mkdirs()
-
-                    val headersSourceDir = File(extractionDir, "assets/headers")
-                    if (headersSourceDir.exists()) {
-                        project.copy {
-                            it.from(headersSourceDir)
-                            it.into(headersDir)
-                            it.include("**/*.h")
-                        }
-
-                        // 5. Register in manifest: name;path_to_a;path_to_headers
-                        // Using a placeholder ${ANDROID_ABI} for CMake
-                        val cmakeLibPath = "${outDir.absolutePath}/\${ANDROID_ABI}/libreact_codegen_$codegenName.a"
-                        sb.append("$codegenName;$cmakeLibPath;${headersDir.absolutePath}\n")
-                    } else {
-                        project.logger.lifecycle(
-                            "RNRepo: Headers not found in assets/headers for $moduleName - will build codegen from sources",
-                        )
-                    }
+                if (hasLib) {
+                    foundAnyLib = true
                 } else {
-                    project.logger.lifecycle(
-                        "RNRepo: Skipping $moduleName from manifest because no .a files were found for $currentBuildType",
-                    )
+                    project.logger.warn("RNRepo: No $currentBuildType codegen library found for $abi in $moduleName")
                 }
             }
+
+            if (!foundAnyLib) {
+                project.logger.lifecycle("RNRepo: Skipping $moduleName — no .a files found for $currentBuildType")
+                return@forEach
+            }
+
+            if (!File(extractionDir, "assets/headers").exists()) {
+                project.logger.warn("RNRepo: No headers in assets/headers for $moduleName, skipping")
+                return@forEach
+            }
+
+            val cmakeLists = File(extractionDir, "assets/cmake/CMakeLists.txt")
+            if (!cmakeLists.exists()) {
+                throw GradleException("RNRepo: Codegen prebuilt $moduleName does not contain assets/cmake/CMakeLists.txt")
+            }
+
+            val npmNameFile = File(extractionDir, "assets/meta/npm_name.txt")
+            val displayName = if (npmNameFile.exists()) npmNameFile.readText().trim() else moduleName
+            project.logger.lifecycle("RNRepo: Registered prebuilt codegen for $displayName (codegen: $codegenName)")
+
+            cmakeListsByCodegenName[codegenName] = cmakeLists
         }
-        codegenListFile.writeText(sb.toString())
+
+        transformAutolinkingConfig(cmakeListsByCodegenName)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun transformAutolinkingConfig(cmakeListsByCodegenName: Map<String, File>) {
+        val outputFile = transformedAutolinkFile.get().asFile
+        outputFile.parentFile.mkdirs()
+
+        val inputFile = autolinkInputFile.orNull?.asFile
+        if (inputFile == null || !inputFile.exists()) {
+            project.logger.warn(
+                "RNRepo: autolinking.json not found, skipping cmake path injection — prebuilt codegen will be ignored, build time will be longer",
+            )
+            // Always produce the declared output so downstream tasks don't fail on a missing input
+            outputFile.writeText("{\"dependencies\":{}}")
+            return
+        }
+
+        if (cmakeListsByCodegenName.isEmpty()) {
+            inputFile.copyTo(outputFile, overwrite = true)
+            return
+        }
+
+        val json = JsonSlurper().parse(inputFile) as MutableMap<String, Any?>
+        val dependencies = json["dependencies"] as? Map<String, Any?> ?: emptyMap()
+        val rewrittenLibraries = mutableSetOf<String>()
+
+        dependencies.values.forEach { dependency ->
+            val dependencyMap = dependency as? MutableMap<String, Any?> ?: return@forEach
+            val platforms = dependencyMap["platforms"] as? MutableMap<String, Any?> ?: return@forEach
+            val android = platforms["android"] as? MutableMap<String, Any?> ?: return@forEach
+            val libraryName = android["libraryName"] as? String ?: return@forEach
+            val cmakeLists = cmakeListsByCodegenName[libraryName] ?: return@forEach
+
+            android["cmakeListsPath"] = cmakeLists.absolutePath
+            rewrittenLibraries.add(libraryName)
+            project.logger.lifecycle("RNRepo: Redirected cmake for $libraryName → prebuilt at ${cmakeLists.absolutePath}")
+        }
+
+        val missingLibraries = cmakeListsByCodegenName.keys - rewrittenLibraries
+        if (missingLibraries.isNotEmpty()) {
+            throw GradleException(
+                "RNRepo: Could not find autolinking entries for prebuilt codegen libraries: " +
+                    missingLibraries.joinToString(", "),
+            )
+        }
+
+        outputFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
+        project.logger.lifecycle("RNRepo: Wrote transformed autolinking.json (${rewrittenLibraries.size} cmake paths redirected)")
     }
 }

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
@@ -40,9 +40,6 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
         if (outDir.exists()) outDir.deleteRecursively()
         outDir.mkdirs()
 
-        val headersOutputDir = File(outDir, "headers")
-        headersOutputDir.mkdirs()
-
         val abis = listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
         val cmakeListsByCodegenName = mutableMapOf<String, File>()
 
@@ -70,19 +67,6 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
             val codegenName = metaFile.readText().trim()
             // release builds use RelWithDebInfo cmake type — artifacts are stored under relwithdebinfo/
             val currentBuildType = if (buildType.get() == "release") "relwithdebinfo" else buildType.get()
-
-            // Merge headers into the shared output directory (kept for packages whose redirected cmake
-            // exposes them via PUBLIC include dirs).
-            val headersSourceDir = File(extractionDir, "assets/headers")
-            if (headersSourceDir.exists()) {
-                project.copy {
-                    it.from(headersSourceDir)
-                    it.into(headersOutputDir)
-                }
-            } else {
-                project.logger.warn("RNRepo: No headers in assets/headers for $moduleName")
-            }
-
             var foundAnyLib = false
 
             abis.forEach { abi ->
@@ -100,37 +84,12 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
             }
 
             if (!foundAnyLib) {
-                // Header-only prebuilt (no compiled .a). The autolinking entry stays pointed at the
-                // package's own jni CMakeLists, which compiles BOTH the package sources and the generated
-                // codegen sources (Props.cpp / EventEmitters.cpp / <name>-generated.cpp …) globbed from
-                // <pkg>/build/generated/source/codegen/jni — the directory codegen would normally populate.
-                // Since we deliberately do not run the codegen generator locally, drop the prebuilt codegen
-                // tree shipped in the AAR (assets/codegen-jni, .h + .cpp) straight into that directory so
-                // the package compiles them. Headers alone are not enough — without the .cpp the linker
-                // fails on undefined codegen symbols.
-                val codegenSrcDir = File(extractionDir, "assets/codegen-jni")
-                if (!codegenSrcDir.exists()) {
-                    throw GradleException(
-                        "RNRepo: header-only codegen prebuilt $moduleName does not contain assets/codegen-jni " +
-                            "(generated codegen sources). Rebuild the AAR with a builder that packages them.",
-                    )
-                }
-                val targetProject = project.rootProject.findProject(":$moduleName")
-                if (targetProject == null) {
-                    throw GradleException(
-                        "RNRepo: $moduleName is a header-only codegen prebuilt but its Gradle project " +
-                            "(:$moduleName) could not be found to place the generated codegen sources",
-                    )
-                }
-                val codegenJniDir = File(targetProject.projectDir, "build/generated/source/codegen/jni")
-                codegenJniDir.mkdirs()
-                project.copy {
-                    it.from(codegenSrcDir)
-                    it.into(codegenJniDir)
-                }
-                project.logger.lifecycle(
-                    "RNRepo: $moduleName has no prebuilt .a — placed prebuilt codegen sources into ${codegenJniDir.absolutePath}",
-                )
+                project.logger.lifecycle("RNRepo: Skipping $moduleName — no .a files found for $currentBuildType")
+                return@forEach
+            }
+
+            if (!File(extractionDir, "assets/headers").exists()) {
+                project.logger.warn("RNRepo: No headers in assets/headers for $moduleName, skipping")
                 return@forEach
             }
 

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/ExtractPrebuiltsTask.kt
@@ -40,6 +40,9 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
         if (outDir.exists()) outDir.deleteRecursively()
         outDir.mkdirs()
 
+        val headersOutputDir = File(outDir, "headers")
+        headersOutputDir.mkdirs()
+
         val abis = listOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
         val cmakeListsByCodegenName = mutableMapOf<String, File>()
 
@@ -67,6 +70,19 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
             val codegenName = metaFile.readText().trim()
             // release builds use RelWithDebInfo cmake type — artifacts are stored under relwithdebinfo/
             val currentBuildType = if (buildType.get() == "release") "relwithdebinfo" else buildType.get()
+
+            // Merge headers into the shared output directory (kept for packages whose redirected cmake
+            // exposes them via PUBLIC include dirs).
+            val headersSourceDir = File(extractionDir, "assets/headers")
+            if (headersSourceDir.exists()) {
+                project.copy {
+                    it.from(headersSourceDir)
+                    it.into(headersOutputDir)
+                }
+            } else {
+                project.logger.warn("RNRepo: No headers in assets/headers for $moduleName")
+            }
+
             var foundAnyLib = false
 
             abis.forEach { abi ->
@@ -84,12 +100,37 @@ abstract class ExtractPrebuiltsTask : DefaultTask() {
             }
 
             if (!foundAnyLib) {
-                project.logger.lifecycle("RNRepo: Skipping $moduleName — no .a files found for $currentBuildType")
-                return@forEach
-            }
-
-            if (!File(extractionDir, "assets/headers").exists()) {
-                project.logger.warn("RNRepo: No headers in assets/headers for $moduleName, skipping")
+                // Header-only prebuilt (no compiled .a). The autolinking entry stays pointed at the
+                // package's own jni CMakeLists, which compiles BOTH the package sources and the generated
+                // codegen sources (Props.cpp / EventEmitters.cpp / <name>-generated.cpp …) globbed from
+                // <pkg>/build/generated/source/codegen/jni — the directory codegen would normally populate.
+                // Since we deliberately do not run the codegen generator locally, drop the prebuilt codegen
+                // tree shipped in the AAR (assets/codegen-jni, .h + .cpp) straight into that directory so
+                // the package compiles them. Headers alone are not enough — without the .cpp the linker
+                // fails on undefined codegen symbols.
+                val codegenSrcDir = File(extractionDir, "assets/codegen-jni")
+                if (!codegenSrcDir.exists()) {
+                    throw GradleException(
+                        "RNRepo: header-only codegen prebuilt $moduleName does not contain assets/codegen-jni " +
+                            "(generated codegen sources). Rebuild the AAR with a builder that packages them.",
+                    )
+                }
+                val targetProject = project.rootProject.findProject(":$moduleName")
+                if (targetProject == null) {
+                    throw GradleException(
+                        "RNRepo: $moduleName is a header-only codegen prebuilt but its Gradle project " +
+                            "(:$moduleName) could not be found to place the generated codegen sources",
+                    )
+                }
+                val codegenJniDir = File(targetProject.projectDir, "build/generated/source/codegen/jni")
+                codegenJniDir.mkdirs()
+                project.copy {
+                    it.from(codegenSrcDir)
+                    it.into(codegenJniDir)
+                }
+                project.logger.lifecycle(
+                    "RNRepo: $moduleName has no prebuilt .a — placed prebuilt codegen sources into ${codegenJniDir.absolutePath}",
+                )
                 return@forEach
             }
 

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -115,9 +115,35 @@ class PrebuildsPlugin : Plugin<Project> {
                         it.transformedAutolinkFile.set(transformedAutolinkFile)
                     }
 
-                // Hook extraction into build lifecycle before native build tasks
-                project.tasks.matching { it.name.startsWith("externalNativeBuild") || it.name == "preBuild" }.all {
-                    it.dependsOn(extractTask)
+                // Hook extraction into build lifecycle before native build tasks and cmake configuration
+                project.tasks
+                    .matching {
+                        it.name.startsWith("externalNativeBuild") ||
+                            it.name.startsWith("configureCMake") ||
+                            it.name == "preBuild"
+                    }.all {
+                        it.dependsOn(extractTask)
+                    }
+
+                // Add extracted headers to the cmake include path so all compilation units can find them,
+                // even when cmake target_include_directories PUBLIC propagation doesn't reach the package's
+                // own source files (e.g. react-native-safe-area-context including its own codegen headers).
+                val headersDir =
+                    project.layout.buildDirectory
+                        .dir("generated/rnrepo/prebuilts/headers")
+                        .get()
+                        .asFile
+                val androidExtension = project.extensions.getByName("android") as? BaseExtension
+                try {
+                    androidExtension
+                        ?.defaultConfig
+                        ?.externalNativeBuild
+                        ?.cmake
+                        ?.cppFlags
+                        ?.add("-I${headersDir.absolutePath}")
+                    logger.lifecycle("Added prebuilt headers to cmake include path: ${headersDir.absolutePath}")
+                } catch (e: Exception) {
+                    logger.warn("Could not add prebuilt headers to cmake include path: ${e.message}")
                 }
 
                 configureReactNativeAutolinkingTask(project, extractTask, transformedAutolinkFile)
@@ -153,8 +179,24 @@ class PrebuildsPlugin : Plugin<Project> {
             // Configure pickFirsts for packages with native libraries that may have duplicates
             configurePickFirsts(project, extension.supportedPackages)
 
-            // Add dependency on generating codegen schema for each library that needs it
-            // Skip packages with hasCodegen=true since they use prebuilt codegen artifacts
+            // Add dependency on generating codegen schema for each library that needs it.
+            //
+            // We run from-source codegen for ALL supported packages, including hasCodegen=true ones.
+            // When a prebuilt-codegen AAR actually ships a compiled libreact_codegen_<name>.a,
+            // ExtractPrebuiltsTask redirects the autolinking cmakeListsPath to the prebuilt cmake, so
+            // the from-source codegen sources are unused and the expensive native C++ compile is still
+            // skipped — only the cheap JS generation runs.
+            //
+            // But some libraries publish header-only codegen AARs that contain headers + a cmake stub
+            // but no .a (e.g. react-native-safe-area-context, whose codegen still emits real sources
+            // such as Props.cpp / EventEmitters.cpp). For those, ExtractPrebuiltsTask finds no .a and
+            // leaves the autolinking entry pointing at the library's own jni/CMakeLists.txt, which
+            // builds react_codegen_<name> from source. That cmake target is compiled in its own
+            // autolinking cmake invocation that does not inherit the app's -I include flags, so it can
+            // only see the generated headers/sources under build/generated/source/codegen/jni. If
+            // codegen never ran from source that directory is empty and the build fails (missing
+            // Props.h / EventEmitters.h, and ultimately the codegen .cpp). Running codegen from source
+            // here is the fallback that keeps those packages building.
             extension.supportedPackages
                 .filter { !it.hasCodegen }
                 .forEach { packageItem ->

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -7,10 +7,15 @@ import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
@@ -89,28 +94,33 @@ class PrebuildsPlugin : Plugin<Project> {
                     it.isCanBeConsumed = false
                 }
 
-            // Configure CMake wrapper before project evaluation
-            project.pluginManager.withPlugin("com.android.application") {
-                val android = project.extensions.findByType(BaseExtension::class.java)
-                if (android != null) {
-                    configureCMakeWrapper(project, android)
-                }
-            }
-
             // Wait for project evaluation to complete remaining setup tasks
             project.afterEvaluate {
-                // Register extraction task for codegen prebuilts
+                if (extension.supportedPackages.none { it.hasCodegen }) {
+                    return@afterEvaluate
+                }
+
+                val transformedAutolinkFile =
+                    project.layout.buildDirectory.file("generated/rnrepo/autolinking/autolinking.json")
+
                 val extractTask =
                     project.tasks.register("extractCodegenPrebuilts", ExtractPrebuiltsTask::class.java) {
                         it.codegenConfiguration.set(codegenConfig)
                         it.outputDir.set(project.layout.buildDirectory.dir("generated/rnrepo/prebuilts"))
                         it.buildType.set(getBuildType(project))
+                        it.autolinkInputFile.set(
+                            project.rootProject.layout.buildDirectory
+                                .file("generated/autolinking/autolinking.json"),
+                        )
+                        it.transformedAutolinkFile.set(transformedAutolinkFile)
                     }
 
                 // Hook extraction into build lifecycle before native build tasks
                 project.tasks.matching { it.name.startsWith("externalNativeBuild") || it.name == "preBuild" }.all {
                     it.dependsOn(extractTask)
                 }
+
+                configureReactNativeAutolinkingTask(project, extractTask, transformedAutolinkFile)
             }
 
             // Check what packages are in project and which are we supporting
@@ -1058,113 +1068,41 @@ class PrebuildsPlugin : Plugin<Project> {
         logger.lifecycle("Packages that fallback to building from sources:${printList(unavailablePackages, "❓")}")
     }
 
-    private fun configureCMakeWrapper(
+    private fun configureReactNativeAutolinkingTask(
         project: Project,
-        android: BaseExtension,
+        extractTask: TaskProvider<ExtractPrebuiltsTask>,
+        transformedAutolinkFile: Provider<RegularFile>,
     ) {
-        val cmakeExt = android.externalNativeBuild.cmake
-        val wrapperFile = File(project.buildDir, "generated/rnrepo/CMakeLists.txt")
-        val codegenListFile = File(project.buildDir, "generated/rnrepo/prebuilts/codegen_libs.txt")
-        val autolinkFile = File(project.buildDir, "generated/autolinking/src/main/jni/Android-autolinking.cmake")
-
-        val userCMake = cmakeExt.path // Store original CMake path before overriding with wrapper
-
-        // Extract project name from user's CMakeLists.txt or use default
-        val projectName =
-            if (userCMake != null && userCMake.exists()) {
-                try {
-                    val projectRegex = """project\s*\(\s*([^)]+)\s*\)""".toRegex()
-                    val match = projectRegex.find(userCMake.readText())
-                    match?.groupValues?.get(1)?.trim() ?: "appmodules"
-                } catch (e: Exception) {
-                    logger.warn("Failed to read project name from ${userCMake.absolutePath}: ${e.message}")
-                    "appmodules"
-                }
-            } else {
-                "appmodules"
+        project.tasks.matching { it.name == "generateAutolinkingNewArchitectureFiles" }.configureEach { task ->
+            task.dependsOn(extractTask)
+            if (setReactNativeAutolinkingInput(task, transformedAutolinkFile)) {
+                logger.lifecycle("Using RNRepo-transformed autolinking config for React Native C++ autolinking")
             }
-
-        val wrapperContent =
-            """
-            cmake_minimum_required(VERSION 3.13)
-            project($projectName)
-
-            # Scrubbing - remove codegen libraries from autolinking to avoid duplicate symbols
-            if(EXISTS "${codegenListFile.absolutePath}" AND EXISTS "${autolinkFile.absolutePath}")
-                file(STRINGS "${codegenListFile.absolutePath}" CODEGEN_LINES)
-                file(READ "${autolinkFile.absolutePath}" AUTOLINK_CONTENT)
-
-                foreach(LINE ${'$'}{CODEGEN_LINES})
-                    string(REPLACE ";" " " ARGS "${'$'}{LINE}")
-                    separate_arguments(ARGS_LIST NATIVE_COMMAND ${'$'}{ARGS})
-                    list(GET ARGS_LIST 0 LIB_NAME)
-
-                    # Remove lines containing the library name (cross-platform)
-                    string(REGEX REPLACE "[^\n]*${'$'}{LIB_NAME}[^\n]*\n" "" AUTOLINK_CONTENT "${'$'}{AUTOLINK_CONTENT}")
-                endforeach()
-
-                file(WRITE "${autolinkFile.absolutePath}" "${'$'}{AUTOLINK_CONTENT}")
-            endif()
-
-            # Include logic
-            if ("${userCMake?.absolutePath ?: ""}" STREQUAL "")
-                # Default RN App Logic (Variables like REACT_ANDROID_DIR provided by NdkConfiguratorUtils)
-                include("${'$'}{REACT_ANDROID_DIR}/cmake-utils/ReactNative-application.cmake")
-            else()
-                include("${userCMake?.absolutePath}")
-            endif()
-
-            function(link_prebuilt_codegen library_name prebuilt_path codegen_jni_dir)
-                set(target_name "react_codegen_${'$'}{library_name}")
-                set(DUMMY_SOURCE "${'$'}{CMAKE_CURRENT_BINARY_DIR}/placeholder_${'$'}{library_name}.cpp")
-
-                if(NOT EXISTS "${'$'}{DUMMY_SOURCE}")
-                    file(WRITE "${'$'}{DUMMY_SOURCE}" "// Generated placeholder for ${'$'}{library_name}\n")
-                endif()
-
-                add_library(${'$'}{target_name} STATIC "${'$'}{DUMMY_SOURCE}")
-
-                target_include_directories(${'$'}{target_name} PUBLIC
-                    ${'$'}{codegen_jni_dir}
-                    ${'$'}{codegen_jni_dir}/react/renderer/components/${'$'}{library_name}
-                )
-
-                target_link_libraries(${'$'}{target_name} ${'$'}{prebuilt_path} fbjni jsi reactnative)
-
-                if(COMMAND target_compile_reactnative_options)
-                    target_compile_reactnative_options(${'$'}{target_name} PRIVATE)
-                endif()
-
-                target_link_libraries(${'$'}{CMAKE_PROJECT_NAME} ${'$'}{target_name})
-
-                target_link_libraries(${'$'}{target_name} common_flags)
-            endfunction()
-
-            # Link Codegen Libs
-            if(EXISTS "${codegenListFile.absolutePath}")
-                message(STATUS "RNRepo: Loading codegen libraries from ${codegenListFile.absolutePath}")
-                file(STRINGS "${codegenListFile.absolutePath}" CODEGEN_LINES)
-                foreach(LINE ${'$'}{CODEGEN_LINES})
-                    string(REPLACE ";" " " ARGS "${'$'}{LINE}")
-                    separate_arguments(ARGS_LIST NATIVE_COMMAND ${'$'}{ARGS})
-                    list(GET ARGS_LIST 0 L_NAME)
-                    list(GET ARGS_LIST 1 L_RAW_PATH)
-                    list(GET ARGS_LIST 2 L_HEADERS)
-                    string(CONFIGURE "${'$'}{L_RAW_PATH}" L_PATH)
-
-                    message(STATUS "Linking codegen lib: ${'$'}{L_NAME} for ABI: ${'$'}{ANDROID_ABI}")
-                    link_prebuilt_codegen("${'$'}{L_NAME}" "${'$'}{L_PATH}" "${'$'}{L_HEADERS}")
-                endforeach()
-            else()
-                message(STATUS "RNRepo: No codegen libraries file found at ${codegenListFile.absolutePath}")
-            endif()
-            """.trimIndent()
-
-        // Generate wrapper file immediately during configuration
-        wrapperFile.parentFile.mkdirs()
-        wrapperFile.writeText(wrapperContent)
-
-        // Set the path BEFORE project evaluation
-        cmakeExt.path = wrapperFile
+        }
     }
+
+    private fun setReactNativeAutolinkingInput(
+        task: Task,
+        transformedAutolinkFile: Provider<RegularFile>,
+    ): Boolean =
+        runCatching {
+            val property =
+                task.javaClass.methods
+                    .firstOrNull { it.name == "getAutolinkInputFile" && it.parameterCount == 0 }
+                    ?.invoke(task) as? RegularFileProperty
+            if (property == null) {
+                logger.warn(
+                    "Could not configure ${task.name}: React Native task does not expose getAutolinkInputFile() — prebuilt codegen will be ignored, build time will be longer",
+                )
+                false
+            } else {
+                property.set(transformedAutolinkFile)
+                true
+            }
+        }.getOrElse { error ->
+            logger.warn(
+                "Could not configure ${task.name} to use RNRepo autolinking config: ${error.message} — prebuilt codegen will be ignored, build time will be longer",
+            )
+            false
+        }
 }

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -1138,7 +1138,17 @@ class PrebuildsPlugin : Plugin<Project> {
                 )
                 false
             } else {
-                property.set(transformedAutolinkFile)
+                // Redirect React Native's autolinking input to our transformed file only when it
+                // actually exists. ExtractPrebuiltsTask writes it solely when it rewrote cmake paths,
+                // so when it is absent (no prebuilt codegen, or autolinking.json was unavailable) we
+                // fall back to React Native's own input instead of an empty/broken config.
+                val originalInput = property.orNull
+                property.set(
+                    task.project.provider {
+                        val transformed = transformedAutolinkFile.get()
+                        if (transformed.asFile.exists() || originalInput == null) transformed else originalInput
+                    },
+                )
                 true
             }
         }.getOrElse { error ->

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -115,35 +115,9 @@ class PrebuildsPlugin : Plugin<Project> {
                         it.transformedAutolinkFile.set(transformedAutolinkFile)
                     }
 
-                // Hook extraction into build lifecycle before native build tasks and cmake configuration
-                project.tasks
-                    .matching {
-                        it.name.startsWith("externalNativeBuild") ||
-                            it.name.startsWith("configureCMake") ||
-                            it.name == "preBuild"
-                    }.all {
-                        it.dependsOn(extractTask)
-                    }
-
-                // Add extracted headers to the cmake include path so all compilation units can find them,
-                // even when cmake target_include_directories PUBLIC propagation doesn't reach the package's
-                // own source files (e.g. react-native-safe-area-context including its own codegen headers).
-                val headersDir =
-                    project.layout.buildDirectory
-                        .dir("generated/rnrepo/prebuilts/headers")
-                        .get()
-                        .asFile
-                val androidExtension = project.extensions.getByName("android") as? BaseExtension
-                try {
-                    androidExtension
-                        ?.defaultConfig
-                        ?.externalNativeBuild
-                        ?.cmake
-                        ?.cppFlags
-                        ?.add("-I${headersDir.absolutePath}")
-                    logger.lifecycle("Added prebuilt headers to cmake include path: ${headersDir.absolutePath}")
-                } catch (e: Exception) {
-                    logger.warn("Could not add prebuilt headers to cmake include path: ${e.message}")
+                // Hook extraction into build lifecycle before native build tasks
+                project.tasks.matching { it.name.startsWith("externalNativeBuild") || it.name == "preBuild" }.all {
+                    it.dependsOn(extractTask)
                 }
 
                 configureReactNativeAutolinkingTask(project, extractTask, transformedAutolinkFile)
@@ -179,24 +153,8 @@ class PrebuildsPlugin : Plugin<Project> {
             // Configure pickFirsts for packages with native libraries that may have duplicates
             configurePickFirsts(project, extension.supportedPackages)
 
-            // Add dependency on generating codegen schema for each library that needs it.
-            //
-            // We run from-source codegen for ALL supported packages, including hasCodegen=true ones.
-            // When a prebuilt-codegen AAR actually ships a compiled libreact_codegen_<name>.a,
-            // ExtractPrebuiltsTask redirects the autolinking cmakeListsPath to the prebuilt cmake, so
-            // the from-source codegen sources are unused and the expensive native C++ compile is still
-            // skipped — only the cheap JS generation runs.
-            //
-            // But some libraries publish header-only codegen AARs that contain headers + a cmake stub
-            // but no .a (e.g. react-native-safe-area-context, whose codegen still emits real sources
-            // such as Props.cpp / EventEmitters.cpp). For those, ExtractPrebuiltsTask finds no .a and
-            // leaves the autolinking entry pointing at the library's own jni/CMakeLists.txt, which
-            // builds react_codegen_<name> from source. That cmake target is compiled in its own
-            // autolinking cmake invocation that does not inherit the app's -I include flags, so it can
-            // only see the generated headers/sources under build/generated/source/codegen/jni. If
-            // codegen never ran from source that directory is empty and the build fails (missing
-            // Props.h / EventEmitters.h, and ultimately the codegen .cpp). Running codegen from source
-            // here is the fallback that keeps those packages building.
+            // Add dependency on generating codegen schema for each library that needs it
+            // Skip packages with hasCodegen=true since they use prebuilt codegen artifacts
             extension.supportedPackages
                 .filter { !it.hasCodegen }
                 .forEach { packageItem ->

--- a/packages/builder/build-library-android.ts
+++ b/packages/builder/build-library-android.ts
@@ -67,12 +67,16 @@ async function patchCMakeListsToStatic(packagePath: string): Promise<void> {
     cmakeListsPath = cmakeListsPath.replace(/^\.\.\//, '');
     
     // Resolve the path relative to the package
-    const absoluteCMakePath = join(packagePath, cmakeListsPath);
+    let absoluteCMakePath = join(packagePath, cmakeListsPath);
     
     if (!existsSync(absoluteCMakePath)) {
       console.log(`   CMakeLists.txt not found at ${absoluteCMakePath}`);
-      return;
+      absoluteCMakePath = join(packagePath, 'android', cmakeListsPath);
+      if (!existsSync(absoluteCMakePath)) {
+        throw new Error(`   CMakeLists.txt not found at ${absoluteCMakePath}`);
+      }
     }
+    console.log(`   CMakeLists.txt found at ${absoluteCMakePath}`);
 
     // Read CMakeLists.txt
     let cmakeContent = readFileSync(absoluteCMakePath, 'utf-8');

--- a/packages/builder/build-library-android.ts
+++ b/packages/builder/build-library-android.ts
@@ -253,6 +253,7 @@ async function buildAAR(appDir: string, license: AllowedLicense) {
           ? ['--init-script', postinstallGradleScriptPath]
           : []),
         `-PrnrepoCodegenName=${packageJson.codegenConfig.name}`,
+        `-PrnrepoNpmName=${libraryName}`,
       ];
       await $`./gradlew ${assembleReleaseArgs}`.cwd(androidPath);
 

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -23,6 +23,50 @@ allprojects { project ->
     }
 }
 
+def generateCMakeContent(codegenName) {
+    // Uses CMAKE_CURRENT_LIST_DIR-relative paths so the file works wherever it is extracted.
+    // Groovy \$ produces a literal $ in the output (cmake variable reference).
+    //
+    // STATIC IMPORTED targets cannot be used with non-INTERFACE keyword in target_link_libraries,
+    // which RN's ReactNative-application.cmake does internally. A real STATIC target (with a
+    // generated placeholder source) works correctly in all CMake linking contexts.
+    return """cmake_minimum_required(VERSION 3.13)
+
+if(CMAKE_BUILD_TYPE)
+    string(TOLOWER "\${CMAKE_BUILD_TYPE}" RNREPO_BUILD_TYPE)
+    # plain Release maps to relwithdebinfo artifacts (relwithdebinfo works with release, the other way round not)
+    if(RNREPO_BUILD_TYPE STREQUAL "release")
+        set(RNREPO_BUILD_TYPE "relwithdebinfo")
+    endif()
+else()
+    set(RNREPO_BUILD_TYPE "relwithdebinfo")
+endif()
+
+set(_rnrepo_src_${codegenName} "\${CMAKE_CURRENT_BINARY_DIR}/rnrepo_placeholder_${codegenName}.cpp")
+if(NOT EXISTS "\${_rnrepo_src_${codegenName}}")
+    file(WRITE "\${_rnrepo_src_${codegenName}}" "// RNRepo placeholder\\n")
+endif()
+
+add_library(react_codegen_${codegenName} STATIC "\${_rnrepo_src_${codegenName}}")
+
+target_include_directories(react_codegen_${codegenName} PUBLIC
+    "\${CMAKE_CURRENT_LIST_DIR}/../headers"
+    "\${CMAKE_CURRENT_LIST_DIR}/../headers/react/renderer/components/${codegenName}"
+)
+
+target_link_libraries(react_codegen_${codegenName}
+    "\${CMAKE_CURRENT_LIST_DIR}/../\${RNREPO_BUILD_TYPE}/\${ANDROID_ABI}/libreact_codegen_${codegenName}.a"
+    fbjni
+    jsi
+    reactnative
+)
+
+if(COMMAND target_compile_reactnative_options)
+    target_compile_reactnative_options(react_codegen_${codegenName} PRIVATE)
+endif()
+"""
+}
+
 def createExtractCodegenBinariesTask(libraryProject, codegenName, buildType) {
     return libraryProject.tasks.register("extractCodegenBinaries${buildType}") {
         onlyIf { codegenName != null }
@@ -35,7 +79,8 @@ def createExtractCodegenBinariesTask(libraryProject, codegenName, buildType) {
                 def staticLib = fileTree(dir: appCxxDir, include: "**/$moduleFolder/**/libreact_codegen_${codegenName}.a")
                     .find { it.path.contains(arch) }
                 if (staticLib) {
-                    def destDir = file("${libraryProject.projectDir}/src/main/assets/${buildType.toLowerCase()}/$arch")
+                    def assetBuildType = buildType == "Release" ? "relwithdebinfo" : buildType.toLowerCase()
+                    def destDir = file("${libraryProject.projectDir}/src/main/assets/${assetBuildType}/$arch")
                     destDir.mkdirs()
                     copy { from staticLib; into destDir }
                     println "📦 Copied ${buildType} codegen library for $arch from ${staticLib.path}"
@@ -43,11 +88,17 @@ def createExtractCodegenBinariesTask(libraryProject, codegenName, buildType) {
                     println "⚠️  Warning: Codegen library not found for $arch in ${appCxxDir.absolutePath}"
                 }
             }
-            // Metadata for the consumer (only for release to avoid duplication)
+            // Metadata — written once (Release only to avoid duplication)
             if (buildType == "Release") {
                 def metaDir = file("${libraryProject.projectDir}/src/main/assets/meta")
                 metaDir.mkdirs()
                 file("${metaDir}/codegen_name.txt").text = codegenName
+                // npm_name.txt lets the consumer map the Gradle artifact ID back to the npm
+                // package name for logging (e.g. @expensify/react-native-live-markdown)
+                def npmName = libraryProject.findProperty('rnrepoNpmName') ?: ''
+                if (npmName) {
+                    file("${metaDir}/npm_name.txt").text = npmName
+                }
             }
         }
     }
@@ -112,6 +163,16 @@ def configureCodegenTasks(project) {
         }
     }
 
+    def packageCodegenCMakeTask = project.tasks.register("packageCodegenCMake") {
+        onlyIf { codegenName != null }
+        doLast {
+            def cmakeDir = file("${project.projectDir}/src/main/assets/cmake")
+            cmakeDir.mkdirs()
+            file("${cmakeDir}/CMakeLists.txt").text = generateCMakeContent(codegenName)
+            println "📦 Packaged codegen CMakeLists.txt to assets/cmake"
+        }
+    }
+
     // Hook extract tasks to app's assemble tasks
     project.rootProject.subprojects.each { subproject ->
         if (subproject.name == 'app') {
@@ -120,7 +181,7 @@ def configureCodegenTasks(project) {
                 assembleDebugTask.finalizedBy(extractDebugTask)
                 println "🔗 Linked extractCodegenBinariesDebug to app's assembleDebug"
             }
-            
+
             def assembleReleaseTask = subproject.tasks.findByName('assembleRelease')
             if (assembleReleaseTask) {
                 assembleReleaseTask.finalizedBy(extractReleaseTask)
@@ -129,16 +190,17 @@ def configureCodegenTasks(project) {
         }
     }
 
-    // Hook into mergeReleaseAssets to ensure headers are copied before AGP scans assets
+    // Hook into mergeReleaseAssets to ensure assets are packaged before AGP scans them
     def mergeAssetsTask = project.tasks.findByName('mergeReleaseAssets')
     if (mergeAssetsTask) {
         mergeAssetsTask.dependsOn(packageHeadersTask)
+        mergeAssetsTask.dependsOn(packageCodegenCMakeTask)
     }
 
     try {
         if (project.hasProperty('android')) {
             def android = project.android
-            
+
             android.sourceSets.main {
                 assets.srcDirs += ["src/main/assets"]
             }
@@ -147,7 +209,7 @@ def configureCodegenTasks(project) {
         println "Warning: Could not configure Android settings for ${project.name}: ${e.message}"
     }
 
-    return [codegenName: codegenName, packageHeadersTask: packageHeadersTask]
+    return [codegenName: codegenName, packageHeadersTask: packageHeadersTask, packageCodegenCMakeTask: packageCodegenCMakeTask]
 }
 
 gradle.projectsEvaluated {

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -173,34 +173,6 @@ def configureCodegenTasks(project) {
         }
     }
 
-    // Package the full generated codegen jni tree (.h + .cpp) so consumers of a header-only
-    // prebuilt (libraries with their own jni CMakeLists that compile the generated sources, e.g.
-    // react-native-safe-area-context) can drop these back into the package's
-    // build/generated/source/codegen/jni and compile them — without re-running the codegen generator.
-    def packageCodegenSourcesTask = project.tasks.register("packageCodegenSources") {
-        onlyIf { codegenName != null }
-
-        def codegenTask = project.tasks.findByName('generateCodegenArtifactsFromSchema')
-        if (codegenTask != null) {
-            dependsOn(codegenTask)
-        }
-
-        doLast {
-            def genJniDir = file("${project.buildDir}/generated/source/codegen/jni")
-            if (genJniDir.exists()) {
-                def destDir = file("${project.projectDir}/src/main/assets/codegen-jni")
-                destDir.mkdirs()
-                project.copy {
-                    from genJniDir
-                    into destDir
-                }
-                println "📦 Packaged generated codegen sources (.h + .cpp) to assets/codegen-jni"
-            } else {
-                println "⚠️  No generated codegen sources found at ${genJniDir.absolutePath}"
-            }
-        }
-    }
-
     // Hook extract tasks to app's assemble tasks
     project.rootProject.subprojects.each { subproject ->
         if (subproject.name == 'app') {
@@ -223,7 +195,6 @@ def configureCodegenTasks(project) {
     if (mergeAssetsTask) {
         mergeAssetsTask.dependsOn(packageHeadersTask)
         mergeAssetsTask.dependsOn(packageCodegenCMakeTask)
-        mergeAssetsTask.dependsOn(packageCodegenSourcesTask)
     }
 
     try {

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -173,6 +173,34 @@ def configureCodegenTasks(project) {
         }
     }
 
+    // Package the full generated codegen jni tree (.h + .cpp) so consumers of a header-only
+    // prebuilt (libraries with their own jni CMakeLists that compile the generated sources, e.g.
+    // react-native-safe-area-context) can drop these back into the package's
+    // build/generated/source/codegen/jni and compile them — without re-running the codegen generator.
+    def packageCodegenSourcesTask = project.tasks.register("packageCodegenSources") {
+        onlyIf { codegenName != null }
+
+        def codegenTask = project.tasks.findByName('generateCodegenArtifactsFromSchema')
+        if (codegenTask != null) {
+            dependsOn(codegenTask)
+        }
+
+        doLast {
+            def genJniDir = file("${project.buildDir}/generated/source/codegen/jni")
+            if (genJniDir.exists()) {
+                def destDir = file("${project.projectDir}/src/main/assets/codegen-jni")
+                destDir.mkdirs()
+                project.copy {
+                    from genJniDir
+                    into destDir
+                }
+                println "📦 Packaged generated codegen sources (.h + .cpp) to assets/codegen-jni"
+            } else {
+                println "⚠️  No generated codegen sources found at ${genJniDir.absolutePath}"
+            }
+        }
+    }
+
     // Hook extract tasks to app's assemble tasks
     project.rootProject.subprojects.each { subproject ->
         if (subproject.name == 'app') {
@@ -195,6 +223,7 @@ def configureCodegenTasks(project) {
     if (mergeAssetsTask) {
         mergeAssetsTask.dependsOn(packageHeadersTask)
         mergeAssetsTask.dependsOn(packageCodegenCMakeTask)
+        mergeAssetsTask.dependsOn(packageCodegenSourcesTask)
     }
 
     try {


### PR DESCRIPTION
## 📝 Description

replace CMake wrapper with autolinking.json injection
Instead of generating a top-level CMakeLists.txt that wrapped the app's
CMake and manually scrubbed codegen entries from autolinking, prebuilt
codegen integration now works by redirecting React Native's autolinking
config before the native build sees it.

Changes:
- add-publishing.gradle now bundles a self-contained assets/cmake/CMakeLists.txt
  inside each AAR. The generated file creates a proper STATIC target (not
  IMPORTED) that links the prebuilt .a — this avoids CMake's restriction on
  IMPORTED targets in non-INTERFACE target_link_libraries calls used internally
  by ReactNative-application.cmake.

- ExtractPrebuiltsTask reads the RN-generated autolinking.json, finds
  dependency entries whose libraryName matches a downloaded prebuilt, and
  rewrites their cmakeListsPath to point at the extracted CMakeLists.txt.

- PrebuildsPlugin hooks into generateAutolinkingNewArchitectureFiles and
  swaps its input with the transformed autolinking.json, so RN's own build
  infrastructure picks up prebuilt cmake paths transparently.

- release build type now consistently maps to relwithdebinfo artifacts in
  both Kotlin task and Gradle script.

- npm package name passed via -PrnrepoNpmName and stored in
  assets/meta/npm_name.txt for improved logging on the consumer side.

## 🧪 Testing

Tested on pure rn app and expo@55 with packages listed below, both apps builded and launched on emulator as expected.
```
react-native-screens 4.25.1 0.85.1
react-native-screens 4.23.0 0.83.6

react-native-worklets 0.8.3 0.85.1
react-native-worklets 0.7.4 0.83.6

react-native-safe-area-context 5.6.2 0.83.6
react-native-safe-area-context 5.8.0 0.85.1

react-native-reanimated 4.2.1 0.83.6
react-native-reanimated 4.3.1 0.85.1

react-native-gesture-handler 2.30.1 0.83.6
react-native-gesture-handler 2.31.2 0.85.1
```