### PR TITLE
move concurrency configuration to global workflow level

### DIFF
--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -33,6 +33,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   EXPO_SDK_MAJOR_VERSION: ${{ github.event.inputs.expo_sdk_major_version || '55' }}
   EXAMPLE_APP: expoExampleApp
@@ -87,9 +91,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    concurrency:
-      group: build-example-expo-app-android-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -149,10 +150,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    concurrency:
-      group: build-example-expo-app-ios-${{ github.ref }}
-      cancel-in-progress: true
-
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -38,6 +38,10 @@ on:
         type: string
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RN_VERSION: ${{ github.event.inputs.rn_version || '0.85.0' }}
   EXAMPLE_APP: rnExampleApp
@@ -91,9 +95,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    concurrency:
-      group: build-example-rn-app-android-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -145,10 +146,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    concurrency:
-      group: build-example-rn-app-ios-${{ github.ref }}
-      cancel-in-progress: true
-
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION

## 📝 Description

Moves the concurrency group and cancel-in-progress flag from the individual Android build job to the global workflow scope.

This fixes a race condition where newer commits were being canceled instead of older ones due to the `needs: check-changes` dependency. Now, the entire previous workflow run will be terminated immediately when a new commit is pushed to the branch.

- old commit
  - hash: 67ba32657885084ebb33da601bf65316cf9e5640
  - build finished
- new commit
  - hash: 8575dc89a2ae574c5a8c6ac330b586c8558fd396 
  - pushed when previous build was running
  - ci on this commit were cancelled (concurrency) - wrong
    - ci old commit was not cancelled - wrong