### PR TITLE
Fix intermittent "collector is null" NPE in debug builds (sequential C++ dependency check)

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resolve worklets framework module map (#352)
 - Detect debug configuration using GCC preprocessor definitions (#367)
+- Run C++ dependencies check sequentially instead of in parallel (#372)
 
 ## [0.1.4] - 2026-05-21
 

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -153,7 +153,11 @@ class PrebuildsPlugin : Plugin<Project> {
             if (getBuildType(project) == "debug") {
                 project.gradle.projectsEvaluated {
                     logger.info("Checking if all dependencies with c++ code have their consumers supported...")
-                    PACKAGES_WITH_CPP.keys.parallelStream().forEach { packageName ->
+                    // Must stay sequential: checkDependencies iterates the subprojects' lazy
+                    // dependency collections, which are not thread-safe to realize concurrently
+                    // (intermittent "Collectors$TypedCollector.collectInto(...) collector is null"
+                    // NPE). See https://github.com/software-mansion/rnrepo/issues/371
+                    PACKAGES_WITH_CPP.keys.forEach { packageName ->
                         val packageItem = extension.projectPackages.find { it.name == packageName }
                         if (packageItem == null) {
                             logger.info("Package $packageName not found in project packages, skipping dependency check.")


### PR DESCRIPTION
⚠️ This was generated by a LLM ⚠️
## Summary

Fixes #371.

On debug builds, the C++ dependency compatibility check registered in `gradle.projectsEvaluated` iterated `PACKAGES_WITH_CPP.keys` with a `parallelStream()`. `checkDependencies` then realizes each subproject's `configurations`/`dependencies` from those worker threads — but Gradle's lazy dependency collections (pending provider collectors) are not thread-safe to realize concurrently. When two threads raced, the configuration phase failed intermittently with:

```
java.lang.NullPointerException (no error message)
> Cannot invoke "org.gradle.api.internal.provider.Collectors$TypedCollector.collectInto(com.google.common.collect.ImmutableCollection$Builder)" because "collector" is null
```

In our app (RN 0.83, ~60 autolinked subprojects) this hit roughly 40% of cold-daemon debug builds, on both Gradle 9.0.0 and 9.3.1.

## Fix

Replace `parallelStream()` with a sequential `forEach`. `PACKAGES_WITH_CPP` has two entries and each check only iterates in-memory dependency declarations, so the parallelism had no measurable benefit (the whole check is a few milliseconds) while introducing the race. A comment marks the loop as intentionally sequential.

## Testing

- `./gradlew test` in `packages/build-tools/gradle-plugin` — passes
- `./gradlew spotlessCheck` — passes
- Real-world verification on the app from #371: published the patched plugin to mavenLocal as `0.2.3-fix371` and ran 8 cold-daemon (`./gradlew --stop` between runs) `app:assembleDevDebug` builds with no other workaround in place: **8/8 passed**, with RNRepo prebuilds confirmed active in the logs. On plugin 0.2.2 the same loop failed ~40% of runs with the NPE above.