### PR TITLE
fix(ios): mint RNREPO build-phase UUIDs without colliding with CocoaPods objects

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Resolve worklets framework module map (#352)
+- Fix corrupted Pods.xcodeproj caused by iOS build-phase UUID collisions (#373)
 
 ## [0.1.4] - 2026-05-21
 

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -429,6 +429,25 @@ def append_build_setting(build_settings, key, value)
   end
 end
 
+# CocoaPods' collision-blind UUID generator can mint our build phases onto UUIDs
+# core objects already hold, corrupting Pods.xcodeproj. Returns a generator that
+# yields free UUIDs in CocoaPods' own 14-char format ('%.6s%07X0'), collision-
+# checking each candidate and walking the counter forward from 0 as CocoaPods
+# does. The cost of scanning past taken slots is negligible (~1ms, paid once
+# since the counter persists across calls).
+# UUID generator in CocoaPods: https://github.com/CocoaPods/CocoaPods/blob/458dd19585c03d706c2dc23238afd3845a4c6000/lib/cocoapods/project.rb#L70
+def build_safe_uuid_generator(pods_project)
+  uuid_prefix = pods_project.root_object.uuid[0, 6]
+  next_uuid_counter = 0
+  lambda do
+    loop do
+      candidate = format('%.6s%07X0', uuid_prefix, next_uuid_counter)
+      next_uuid_counter += 1
+      return candidate unless pods_project.objects_by_uuid.key?(candidate)
+    end
+  end
+end
+
 def rnrepo_post_install(installer_context)
   # Check if plugin is disabled via environment variable
   if ENV['DISABLE_RNREPO']
@@ -473,10 +492,14 @@ def rnrepo_post_install(installer_context)
   prebuilt_pod_names = (Pod::Installer.prebuilt_rnrepo_pods || []).map { |pod| pod[:name] }
   # Run order is alphabetical. This script must run before the '[CP] Copy XCFrameworks` script
   script_name = '[AA RUN FIRST] RNREPO Build Start'
+
+  pods_project = installer_context.pods_project
+  generate_safe_uuid = build_safe_uuid_generator(pods_project)
+
   # Add build phase script ONLY to targets that have prebuilt frameworks
-  installer_context.pods_project.targets.each do |target|
+  pods_project.targets.each do |target|
     target_name = target.name
-    
+
     # Only add build phase to targets that were prebuilt
     matches_prebuilt_pod = prebuilt_pod_names.any? do |pod_name|
       target_name.downcase.start_with?(pod_name.to_s.downcase)
@@ -485,11 +508,18 @@ def rnrepo_post_install(installer_context)
 
     # Remove any existing RNREPO build phase first
     target.build_phases.select { |phase| phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == script_name }.each(&:remove_from_project)
-    
-    # Create shell script build phase
-    build_phase = target.new_shell_script_build_phase(script_name)
+
+    # Build the phase with a pre-verified UUID instead of target.new_shell_script_build_phase,
+    # which would mint one through CocoaPods' collision-blind generator and risk evicting a
+    # core object. This mirrors what Xcodeproj::Project#new does, minus that generator, see:
+    # https://github.com/CocoaPods/Xcodeproj/blob/c12d2ae619ae42f947a6b07d865f69948c752df5/lib/xcodeproj/project/object/native_target.rb#L304
+    # https://github.com/CocoaPods/Xcodeproj/blob/c12d2ae619ae42f947a6b07d865f69948c752df5/lib/xcodeproj/project.rb#L433
+    build_phase = Xcodeproj::Project::Object::PBXShellScriptBuildPhase.new(pods_project, generate_safe_uuid.call)
+    build_phase.initialize_defaults
+    build_phase.name = script_name
     build_phase.shell_script = script_content
-    
+    target.build_phases << build_phase
+
     CocoapodsRnrepo::Logger.log "  Added build phase to #{target_name}"
   end
 


### PR DESCRIPTION
## 📝 Description

Fixes #362.

On iOS, the cocoapods plugin injects an `[AA RUN FIRST] RNREPO Build Start` shell-script build phase into every prebuilt pod target during `post_install`. Those phases were created with `target.new_shell_script_build_phase`, which mints UUIDs through CocoaPods' `Pod::Project` generator. That generator is **collision-blind by design**, and under the right conditions the injected phases land on UUIDs that core project objects already hold — evicting the root `PBXProject`, main group, or Products group from `objects_by_uuid` and corrupting `Pods.xcodeproj`. Xcode then reports the project as *"damaged"*, builds only the app target, and every pod modulemap goes missing, surfacing as `no such module '…'`.

### Why it happens

CocoaPods overrides Xcodeproj's UUID allocator for speed. [`Pod::Project#generate_available_uuid_list`](https://github.com/CocoaPods/CocoaPods/blob/458dd19585c03d706c2dc23238afd3845a4c6000/lib/cocoapods/project.rb#L70) mints UUIDs from a sequential counter in the format `'%.6s%07X0'` (6-char prefix + 7-hex counter + trailing `0`) and **skips the collision check** that vanilla Xcodeproj performs (`candidates - (@generated_uuids + uuids)`). Its own comment justifies this: *"we don't need to check for collisions (as the Pods project is regenerated each time, and thus all UUIDs will have come from this method)."*

That safety rests on one invariant: **the counter is the sole, monotonic source of every UUID in the project.** Two steps in a normal install break it:

1. **`stabilize_target_uuids`** rewrites native-target UUIDs to MD5 hashes, and at the end resets `@generated_uuids` down to just the *leftover unused pool* (`uuid_generator.rb` does `project.@generated_uuids = project.@available_uuids`). The counter now points **backward**, into offsets the live objects still occupy. Nothing has collided yet because nothing new has been allocated.
2. **rnrepo injects build phases.** The leftover pool (the high, unused tail) is handed out first and is safe. But once the injected phases exhaust that tail, the generator mints a **fresh batch starting at the reset counter value** — back down in occupied space — and silently overwrites core objects via `objects_by_uuid[uuid] = self` (last writer wins). `pod install` reports success; the corruption only surfaces when Xcode reopens the saved project and finds `rootObject` resolving to a shell-script phase.

This is why the failure looks flaky: it triggers precisely when `injectedPhases > 100 − (podObjectCount mod 100)`, and both terms drift with the pod graph.

### The fix

Mint rnrepo's phase UUIDs in **CocoaPods' own 14-char format**, but collision-check each candidate against `objects_by_uuid` and walk the counter forward from `0` (skipping taken slots), exactly the check CocoaPods omits. The phase is then constructed directly — mirroring what [`Xcodeproj::Project#new`](https://github.com/CocoaPods/Xcodeproj/blob/c12d2ae619ae42f947a6b07d865f69948c752df5/lib/xcodeproj/project.rb#L433) and [`new_shell_script_build_phase`](https://github.com/CocoaPods/Xcodeproj/blob/c12d2ae619ae42f947a6b07d865f69948c752df5/lib/xcodeproj/project/object/native_target.rb#L304) do, minus the collision-blind `generate_uuid` — so the phase is born on a pre-verified free UUID and **no object is ever evicted**.

This stays faithful to CocoaPods: same 14-char string format, same forward allocation direction, no allocator override, no changes to CocoaPods' generation mechanism. The cost of scanning past taken slots is negligible — ~1ms for a project with thousands of objects, paid once since the counter persists across phases.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

The injection logic was integration-tested against synthetic Pods projects deliberately forced into the corrupt state (collisions on the root object and Products group), across 1/5/25 prebuilt-pod targets, run twice for idempotency. In every case: the project reopens **valid**, **zero duplicate UUIDs**, exactly one phase per target, all phases reachable in `objects_by_uuid`, and every rnrepo UUID is a well-formed 14-char CocoaPods UUID.

It was also verified end-to-end on a real `pod install` (250 pods, `deterministic_uuids: false`): exit 0, all phases minted via the new path, generated `Pods.xcodeproj` opens with 0 duplicate UUIDs, the root object remains a single `PBXProject`, and `xcodebuild -project Pods/Pods.xcodeproj -list` (Xcode's own parser) succeeds with no "damaged project" error.

**Steps to reproduce:**
1. An iOS app using rnrepo prebuilt pods with `install! 'cocoapods', :deterministic_uuids => false` (the React Native default).
2. Run `pod install` with enough prebuilt pods that the injected build phases overflow the post-`stabilize` leftover UUID pool (`injectedPhases > 100 − (podObjectCount mod 100)`).
3. Open or build the workspace → Xcode reports `Pods.xcodeproj` as *"damaged and cannot be opened"*; the build proceeds without pod modulemaps and fails with `no such module '…'`.

## 🔀 Other solutions considered

**Mirror `expo-modules-autolinking`'s allocator override** — expo solves the same class of bug by overriding `generate_available_uuid_list` with a collision-safe **random 24-char** generator. Rejected here because a 24-char UUID is foreign to the 14-char namespace CocoaPods uses for the Pods project; it swaps out CocoaPods' allocation mechanism rather than complementing it, produces noisier `.pbxproj` diffs, and we wanted rnrepo's objects to be indistinguishable in format from the ones CocoaPods authors. (expo's choice is correct *for expo's context* — it injects into native xcodeproj projects where 24-char random is the native format; it isn't sharing the `Pod::Project` counter.)

**Allocate from the top of the counter range (walk down from `0xFFFFFFF`)** — O(1) and segregates rnrepo's UUIDs into an unused high region. Implemented and then reverted: it parks UUIDs far from where a fresh allocation would naturally land and risks surprising any tooling that assumes Pods UUIDs are contiguous from `0` (incremental-install diffing, UUID-range heuristics). The O(1) win over forward iteration is immaterial (~1ms), so it wasn't worth the deviation.

**High-water-mark counter resync** — compute the highest live sequential offset and push `@generated_uuids` above it before allocating, restoring CocoaPods' monotonic invariant. Rejected because it reaches into and mutates CocoaPods' allocator internals (`@generated_uuids`/`@available_uuids`), making it more fragile across CocoaPods/Xcodeproj versions than simply checking each candidate.

**Custom prefix / non-standard length UUIDs** — carve rnrepo a private namespace via its own 6-char prefix or a different string length. Rejected as an anti-pattern: an odd-length or non-hex UUID relies on Xcode's *undocumented* tolerance for non-standard UUID shapes (Xcode is the layer that rejects the corrupt project in this very bug), so it trades a known-safe format for a bet on parser leniency.

**Naive post-creation collision guard** — create the phase via `new_shell_script_build_phase`, then check `objects_by_uuid[phase.uuid]` and re-key on conflict. Rejected because it doesn't work: by the time the phase exists it has *already* overwritten the colliding core object in the map, so the guard has no way to recover what was evicted. The fix has to prevent the collision at mint time, which is what this PR does.

**Write the corrected project to disk in `post_install`** — re-key collisions and `File.write` the `.pbxproj`. Rejected as a guaranteed no-op: CocoaPods runs `post_install` and then calls `project.save` afterward, re-serializing the in-memory graph and clobbering any on-disk edit.

**Pre-grow / extend the UUID pool** — mint a larger batch up front so rnrepo never forces a fresh one. Rejected because pool size is a red herring: every UUID in a fresh batch still starts at the poisoned reset offset, so a bigger batch produces *more* colliding UUIDs, not fewer — it triggers the bug rather than deferring it.

**Curative re-key sweep in the consumer's `post_install`** — walk the final object graph after all hooks and re-key any intruder that shares a UUID with a core object (the workaround in the issue report). It works and is order-independent, but it belongs in the consumer's Podfile, not in rnrepo — this PR fixes the trigger at its source so consumers don't need the band-aid.

**Fix it upstream in CocoaPods** — make `generate_available_uuid_list` collision-aware again, or stop `stabilize_target_uuids` rewinding the counter below the high-water mark. This is arguably the true root cause and would protect every plugin in every order, but it's outside rnrepo's control and can't ship on a useful timeline; the right scope for this PR is for rnrepo to stop being the trigger.
