### PR TITLE
update rngh libraries

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -20,13 +20,23 @@
     "postInstallScriptPath": "postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts",
     "android": [
       {
-        "versionMatcher": "*",
+        "versionMatcher": "<3.0.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=3.0.0",
+        "reactNativeVersion": ">=0.82 <0.86",
         "publishedAfterDate": "2025-01-01"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
+        "versionMatcher": "<3.0.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=3.0.0",
+        "reactNativeVersion": ">=0.82 <0.86",
         "publishedAfterDate": "2025-01-01"
       }
     ]

--- a/packages/database/src/get-failed-builds.ts
+++ b/packages/database/src/get-failed-builds.ts
@@ -78,6 +78,9 @@ async function checkIssue(build: BuildRow): Promise<IssueResult> {
     } else if (outputJob.includes('Unable to find a specification for `RNWorklets` depended upon by `RNReanimated`')) {
       // old issue in ci where worklets were not properly installed
       return 'fixable';
+    } else if (outputJob.includes('hunks failed--saving rejects')) {
+      // failed patching
+      return 'fixable';
     } else {
       // todo: add more cases in future
     }

--- a/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
+++ b/postInstallScripts/react-native-gesture-handler/react-native-gesture-handler.ts
@@ -15,7 +15,7 @@ const COMPATIBILITY_MATRIX = [
   {
     rn: '>=0.80.0 <0.85.0',
     reanimated: '4.2.2',
-    worklets: '0.7.3'
+    worklets: '0.7.4'
   },
   {
     rn: '>=0.77.0 <=0.79.x',


### PR DESCRIPTION
## 📝 Description

- rngh@3.0.0 have introduced the Compatibility with React Native versions:
  - https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation
- worklets 0.7.4 have rn@0.84 
  - compatibility.json: "react-native": ["0.79", "0.80", "0.81", "0.82", "0.83", "0.84"]
