### PR TITLE
feat: add allowList support for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ To restrict RNRepo to a subset of libraries without having to manually deny ever
 }
 ```
 
-When `allowList` is present for a platform, only the listed libraries will use prebuilt artifacts. Everything else falls through to building from source. If `allowList` is absent, all libraries are eligible (subject to `denyList`). If both are set, `denyList` takes precedence.
+When `allowList` is present for a platform, only the listed libraries will use prebuilt artifacts. Everything else falls through to building from source. If `allowList` is absent, all libraries are eligible (subject to `denyList`).
+
+`denyList` and `allowList` are mutually exclusive *per platform*. Configuring both for the same platform in `rnrepo.config.json` will raise an error during the build — pick whichever fits your use case. Using a `denyList` for one platform and an `allowList` for another is allowed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ To opt out of using RNRepo for specific libraries (for example, if you have loca
 
 This configuration permanently excludes the listed libraries from RNRepo prebuilds, forcing them to build from source in all builds.
 
+### Enable RNRepo for specific libraries only
+
+To restrict RNRepo to a subset of libraries without having to manually deny everything else, use `allowList`:
+
+```json
+{
+  "allowList": {
+    "android": ["library-name-1"],
+    "ios": ["library-name-2"]
+  }
+}
+```
+
+When `allowList` is present for a platform, only the listed libraries will use prebuilt artifacts. Everything else falls through to building from source. If `allowList` is absent, all libraries are eligible (subject to `denyList`). If both are set, `denyList` takes precedence.
+
 ---
 
 ## Troubleshooting

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for allowList in `rnrepo.config.json` (#383)
+
 ### Fixed
 - Fix Android substitution prefix matching (#385)
 

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -66,7 +66,7 @@ end
 def get_ios_denylist(workspace_root)
   config = load_rnrepo_config(workspace_root)
   denylist_config = config['denyList'] || config['denylist'] || {}
-  denylist_config['ios'] || []
+  denylist_config['ios']
 end
 
 def get_ios_allowlist(workspace_root)
@@ -169,12 +169,12 @@ def rnrepo_pre_install(installer_context)
   # Ensure denyList and allowList are mutually exclusive for iOS.
   # The lists are per-platform, so configuring an allowList for one platform
   # and a denyList for another is allowed.
-  if ios_denylist && !ios_denylist.empty? && ios_allowlist
+  if ios_denylist && ios_allowlist
     raise "RNRepo: Both 'denyList' and 'allowList' are configured for iOS in rnrepo.config.json. Please use only one of them."
   end
 
   # Identify which pods to reject based on the active configuration
-  rejected_pods = if ios_denylist && !ios_denylist.empty?
+  rejected_pods = if ios_denylist
                     rn_pods.select { |pod| ios_denylist.include?(pod[:npm_package_name]) }
                   elsif ios_allowlist
                     rn_pods.reject { |pod| ios_allowlist.include?(pod[:npm_package_name]) }

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -163,27 +163,28 @@ def rnrepo_pre_install(installer_context)
   failed_pods = []
   denied_pods = []
 
-  # Handle denylist
   ios_denylist = get_ios_denylist(workspace_root)
-  rn_pods = rn_pods.reject do |pod_info|
-    if ios_denylist.include?(pod_info[:npm_package_name])
-      denied_pods << pod_info[:name]
-      true
-    else
-      false
-    end
+  ios_allowlist = get_ios_allowlist(workspace_root)
+
+  # Ensure denyList and allowList are mutually exclusive for iOS.
+  # The lists are per-platform, so configuring an allowList for one platform
+  # and a denyList for another is allowed.
+  if ios_denylist && !ios_denylist.empty? && ios_allowlist
+    raise "RNRepo: Both 'denyList' and 'allowList' are configured for iOS in rnrepo.config.json. Please use only one of them."
   end
 
-  # Handle allowlist
-  ios_allowlist = get_ios_allowlist(workspace_root)
-  unless ios_allowlist.nil?
-    rn_pods = rn_pods.reject do |pod_info|
-      unless ios_allowlist.include?(pod_info[:npm_package_name])
-        denied_pods << pod_info[:name]
-        true
-      end
-    end
-  end
+  # Identify which pods to reject based on the active configuration
+  rejected_pods = if ios_denylist && !ios_denylist.empty?
+                    rn_pods.select { |pod| ios_denylist.include?(pod[:npm_package_name]) }
+                  elsif ios_allowlist
+                    rn_pods.reject { |pod| ios_allowlist.include?(pod[:npm_package_name]) }
+                  else
+                    []
+                  end
+
+  # Update lists
+  rn_pods -= rejected_pods
+  denied_pods.concat(rejected_pods.map { |pod| pod[:name] })
 
   # Add expo pod to installer context for later use in post_install
   Pod::Installer.expo_pod = rn_pods.find { |pod| pod[:name] == 'Expo' }

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -69,6 +69,12 @@ def get_ios_denylist(workspace_root)
   denylist_config['ios'] || []
 end
 
+def get_ios_allowlist(workspace_root)
+  config = load_rnrepo_config(workspace_root)
+  allowlist_config = config['allowList'] || config['allowlist'] || {}
+  allowlist_config['ios']
+end
+
 def get_ios_cache_path(workspace_root)
   config = load_rnrepo_config(workspace_root)
   return File.expand_path('~/.rnrepo-cache') unless config.key?('xcframeworksCacheDir')
@@ -165,6 +171,17 @@ def rnrepo_pre_install(installer_context)
       true
     else
       false
+    end
+  end
+
+  # Handle allowlist
+  ios_allowlist = get_ios_allowlist(workspace_root)
+  unless ios_allowlist.nil?
+    rn_pods = rn_pods.reject do |pod_info|
+      unless ios_allowlist.include?(pod_info[:npm_package_name])
+        denied_pods << pod_info[:name]
+        true
+      end
     end
   end
 

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -54,7 +54,6 @@ open class PackagesManager {
     var supportedPackages: Set<PackageItem> = mutableSetOf()
     var reactNativeVersion: String = ""
     var denyList: Set<String> = setOf()
-    var allowList: Set<String>? = null
 }
 
 class PrebuildsPlugin : Plugin<Project> {
@@ -478,23 +477,48 @@ class PrebuildsPlugin : Plugin<Project> {
             // Check for both 'denyList' and 'denylist' (case-insensitive variants)
             @Suppress("UNCHECKED_CAST")
             val denyListData = (json["denyList"] ?: json["denylist"]) as? Map<String, Any>
-            val denyList = denyListData?.get("android") as? List<String>
-            if (denyList != null) {
-                logger.lifecycle("Loaded deny list from config: $denyList")
-                extension.denyList = denyList.map { toGradleName(it) }.toSet()
-            } else {
-                logger.info("No denyList found in config file. Using empty deny list.")
-            }
 
             @Suppress("UNCHECKED_CAST")
             val allowListData = (json["allowList"] ?: json["allowlist"]) as? Map<String, Any>
+
+            @Suppress("UNCHECKED_CAST")
+            val denyList = denyListData?.get("android") as? List<String>
+
+            @Suppress("UNCHECKED_CAST")
             val allowList = allowListData?.get("android") as? List<String>
-            if (allowList != null) {
-                logger.lifecycle("Loaded allow list from config: $allowList")
-                extension.allowList = allowList.map { toGradleName(it) }.toSet()
-            } else {
-                logger.info("No allowList found in config file. All packages are allowed.")
+
+            // denyList and allowList are mutually exclusive for Android: configuring
+            // both is ambiguous. The lists are per-platform, so configuring an
+            // allowList for one platform and a denyList for another is allowed.
+            if (denyList != null && allowList != null) {
+                throw GradleException(
+                    "[RNRepo] Both 'denyList' and 'allowList' are configured for Android in $CONFIG_FILE_NAME. " +
+                        "Please use only one of them.",
+                )
             }
+
+            if (denyList != null) {
+                logger.lifecycle("Loaded deny list from config: $denyList")
+                extension.denyList = denyList.map { toGradleName(it) }.toSet()
+                return
+            }
+
+            // An allowList is just the inverse of a denyList: deny every project
+            // package that is not explicitly allowed.
+            if (allowList != null) {
+                val allowed = allowList.map { toGradleName(it) }.toSet()
+                extension.denyList =
+                    extension.projectPackages
+                        .map { it.name }
+                        .filterNot { allowed.contains(it) }
+                        .toSet()
+                logger.lifecycle("Loaded allow list from config: $allowList. Denying all other packages: ${extension.denyList}")
+                return
+            }
+
+            logger.info("No denyList or allowList found in config file. Using empty deny list.")
+        } catch (e: GradleException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Error parsing $CONFIG_FILE_NAME: ${e.message}. Using empty deny list.")
         }
@@ -524,16 +548,6 @@ class PrebuildsPlugin : Plugin<Project> {
         }
         logger.info("Package $packageName is not denied.")
         return true
-    }
-
-    private fun isPackageAllowed(
-        packageName: String,
-        extension: PackagesManager,
-    ): Boolean {
-        val allowList = extension.allowList ?: return true
-        return allowList.contains(packageName).also { allowed ->
-            if (!allowed) logger.info("Package $packageName is not in allow list, skipping in RNRepo.")
-        }
     }
 
     private fun resolveRNRepoRepositories(repositories: RepositoryHandler): List<MavenArtifactRepository> {
@@ -920,12 +934,11 @@ class PrebuildsPlugin : Plugin<Project> {
         project: Project,
     ) {
         val isDenied = !isPackageNotDenied(packageItem.name, extension)
-        val isNotAllowed = !isPackageAllowed(packageItem.name, extension)
         val checkFailed = !isSpecificCheckPassed(packageItem, extension, supportedPackages, project)
         val isUnavailable = !isPackageAvailable(packageItem, extension.reactNativeVersion, httpRepositories)
 
         when {
-            isDenied || isNotAllowed || checkFailed || isUnavailable -> {
+            isDenied || checkFailed || isUnavailable -> {
                 if (isUnavailable) {
                     unavailablePackages.add(packageItem)
                 }

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -54,6 +54,7 @@ open class PackagesManager {
     var supportedPackages: Set<PackageItem> = mutableSetOf()
     var reactNativeVersion: String = ""
     var denyList: Set<String> = setOf()
+    var allowList: Set<String>? = null
 }
 
 class PrebuildsPlugin : Plugin<Project> {
@@ -484,6 +485,16 @@ class PrebuildsPlugin : Plugin<Project> {
             } else {
                 logger.info("No denyList found in config file. Using empty deny list.")
             }
+
+            @Suppress("UNCHECKED_CAST")
+            val allowListData = (json["allowList"] ?: json["allowlist"]) as? Map<String, Any>
+            val allowList = allowListData?.get("android") as? List<String>
+            if (allowList != null) {
+                logger.lifecycle("Loaded allow list from config: $allowList")
+                extension.allowList = allowList.map { toGradleName(it) }.toSet()
+            } else {
+                logger.info("No allowList found in config file. All packages are allowed.")
+            }
         } catch (e: Exception) {
             logger.error("Error parsing $CONFIG_FILE_NAME: ${e.message}. Using empty deny list.")
         }
@@ -513,6 +524,16 @@ class PrebuildsPlugin : Plugin<Project> {
         }
         logger.info("Package $packageName is not denied.")
         return true
+    }
+
+    private fun isPackageAllowed(
+        packageName: String,
+        extension: PackagesManager,
+    ): Boolean {
+        val allowList = extension.allowList ?: return true
+        return allowList.contains(packageName).also { allowed ->
+            if (!allowed) logger.info("Package $packageName is not in allow list, skipping in RNRepo.")
+        }
     }
 
     private fun resolveRNRepoRepositories(repositories: RepositoryHandler): List<MavenArtifactRepository> {
@@ -899,11 +920,12 @@ class PrebuildsPlugin : Plugin<Project> {
         project: Project,
     ) {
         val isDenied = !isPackageNotDenied(packageItem.name, extension)
+        val isNotAllowed = !isPackageAllowed(packageItem.name, extension)
         val checkFailed = !isSpecificCheckPassed(packageItem, extension, supportedPackages, project)
         val isUnavailable = !isPackageAvailable(packageItem, extension.reactNativeVersion, httpRepositories)
 
         when {
-            isDenied || checkFailed || isUnavailable -> {
+            isDenied || isNotAllowed || checkFailed || isUnavailable -> {
                 if (isUnavailable) {
                     unavailablePackages.add(packageItem)
                 }

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -254,6 +254,101 @@ class PrebuildsPluginHelperMethodsTest {
     }
 
     @Test
+    fun `loadDenyList should parse allowList from config file correctly`() {
+        // Given
+        val extension = PackagesManager()
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+        {
+            "allowList": {
+                "android": ["react-native-reanimated", "react-native-screens"]
+            }
+        }
+        """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.allowList).containsExactlyInAnyOrder(
+            "react-native-reanimated",
+            "react-native-screens",
+        )
+    }
+
+    @Test
+    fun `loadDenyList should leave allowList null when allowList key is absent`() {
+        // Given
+        val extension = PackagesManager()
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+        {
+            "denyList": {
+                "android": ["react-native-vector-icons"]
+            }
+        }
+        """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.allowList).isNull()
+    }
+
+    @Test
+    fun `loadDenyList should leave allowList null when android key is absent from allowList`() {
+        // Given
+        val extension = PackagesManager()
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+        {
+            "allowList": {
+                "ios": ["react-native-reanimated"]
+            }
+        }
+        """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.allowList).isNull()
+    }
+
+    @Test
+    fun `loadDenyList should set allowList to empty set when android key is explicitly empty`() {
+        // Given
+        val extension = PackagesManager()
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+        {
+            "allowList": {
+                "android": []
+            }
+        }
+        """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.allowList).isNotNull().isEmpty()
+    }
+
+    @Test
     fun `isPackageNotDenied should return false for denied packages`() {
         // Given
         val extension = PackagesManager()
@@ -345,6 +440,81 @@ class PrebuildsPluginHelperMethodsTest {
         assertThat(appMatchesAppProject).isTrue()
         assertThat(appMatchesAppCheckModule).isFalse()
         assertThat(appCheckMatchesAppCheckModule).isTrue()
+    }
+
+    @Test
+    fun `isPackageAllowed should return true when allowList is null`() {
+        // Given
+        val extension = PackagesManager() // allowList defaults to null
+
+        // When
+        val result = invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageAllowed",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-reanimated",
+            extension,
+        )
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isPackageAllowed should return true for packages in the allowList`() {
+        // Given
+        val extension = PackagesManager()
+        extension.allowList = setOf("react-native-reanimated", "react-native-screens")
+
+        // When
+        val result = invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageAllowed",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-reanimated",
+            extension,
+        )
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `isPackageAllowed should return false for packages not in the allowList`() {
+        // Given
+        val extension = PackagesManager()
+        extension.allowList = setOf("react-native-reanimated")
+
+        // When
+        val result = invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageAllowed",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-screens",
+            extension,
+        )
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isPackageAllowed should return false for all packages when allowList is empty`() {
+        // Given
+        val extension = PackagesManager()
+        extension.allowList = emptySet()
+
+        // When
+        val result = invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageAllowed",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-reanimated",
+            extension,
+        )
+
+        // Then
+        assertThat(result).isFalse()
     }
 
     @Test
@@ -533,6 +703,34 @@ class PrebuildsPluginHelperMethodsTest {
 
         // Then
         assertThat(result).isEqualTo("0.81.5")
+    }
+
+    @Test
+    fun `denyList should take precedence over allowList`() {
+        // Given
+        val extension = PackagesManager()
+        extension.denyList = setOf("react-native-reanimated")
+        extension.allowList = setOf("react-native-reanimated")
+
+        // When
+        val isDenied = !invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageNotDenied",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-reanimated",
+            extension,
+        )
+        val isAllowed = invokePrivateMethod<Boolean>(
+            plugin,
+            "isPackageAllowed",
+            arrayOf(String::class.java, PackagesManager::class.java),
+            "react-native-reanimated",
+            extension,
+        )
+
+        // Then
+        assertThat(isDenied).isTrue()
+        assertThat(isAllowed).isTrue() // allowList passes, but denyList wins upstream in checkIfPackageIsSupported
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -4,6 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -254,18 +256,24 @@ class PrebuildsPluginHelperMethodsTest {
     }
 
     @Test
-    fun `loadDenyList should parse allowList from config file correctly`() {
+    fun `loadDenyList should convert allowList into a denyList of non-allowed packages`() {
         // Given
         val extension = PackagesManager()
+        extension.projectPackages =
+            setOf(
+                PackageItem("react-native-reanimated", "1.0.0", "react-native-reanimated"),
+                PackageItem("react-native-screens", "1.0.0", "react-native-screens"),
+                PackageItem("react-native-vector-icons", "1.0.0", "react-native-vector-icons"),
+            )
         val configFile = File(tempDir, "rnrepo.config.json")
         configFile.writeText(
             """
-        {
-            "allowList": {
-                "android": ["react-native-reanimated", "react-native-screens"]
+            {
+                "allowList": {
+                    "android": ["react-native-reanimated", "react-native-screens"]
+                }
             }
-        }
-        """.trimIndent(),
+            """.trimIndent(),
         )
         setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
 
@@ -273,79 +281,93 @@ class PrebuildsPluginHelperMethodsTest {
         invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
 
         // Then
-        assertThat(extension.allowList).containsExactlyInAnyOrder(
+        assertThat(extension.denyList).containsExactlyInAnyOrder("react-native-vector-icons")
+    }
+
+    @Test
+    fun `loadDenyList should not invert denyList when allowList is absent`() {
+        // Given
+        val extension = PackagesManager()
+        extension.projectPackages =
+            setOf(
+                PackageItem("react-native-reanimated", "1.0.0", "react-native-reanimated"),
+                PackageItem("react-native-vector-icons", "1.0.0", "react-native-vector-icons"),
+            )
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+            {
+                "denyList": {
+                    "android": ["react-native-vector-icons"]
+                }
+            }
+            """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.denyList).containsExactlyInAnyOrder("react-native-vector-icons")
+    }
+
+    @Test
+    fun `loadDenyList should leave denyList empty when allowList has no android key`() {
+        // Given
+        val extension = PackagesManager()
+        extension.projectPackages =
+            setOf(
+                PackageItem("react-native-reanimated", "1.0.0", "react-native-reanimated"),
+            )
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+            {
+                "allowList": {
+                    "ios": ["react-native-reanimated"]
+                }
+            }
+            """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.denyList).isEmpty()
+    }
+
+    @Test
+    fun `loadDenyList should deny all packages when allowList android is empty`() {
+        // Given
+        val extension = PackagesManager()
+        extension.projectPackages =
+            setOf(
+                PackageItem("react-native-reanimated", "1.0.0", "react-native-reanimated"),
+                PackageItem("react-native-screens", "1.0.0", "react-native-screens"),
+            )
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+            {
+                "allowList": {
+                    "android": []
+                }
+            }
+            """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+
+        // Then
+        assertThat(extension.denyList).containsExactlyInAnyOrder(
             "react-native-reanimated",
             "react-native-screens",
         )
-    }
-
-    @Test
-    fun `loadDenyList should leave allowList null when allowList key is absent`() {
-        // Given
-        val extension = PackagesManager()
-        val configFile = File(tempDir, "rnrepo.config.json")
-        configFile.writeText(
-            """
-        {
-            "denyList": {
-                "android": ["react-native-vector-icons"]
-            }
-        }
-        """.trimIndent(),
-        )
-        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
-
-        // When
-        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
-
-        // Then
-        assertThat(extension.allowList).isNull()
-    }
-
-    @Test
-    fun `loadDenyList should leave allowList null when android key is absent from allowList`() {
-        // Given
-        val extension = PackagesManager()
-        val configFile = File(tempDir, "rnrepo.config.json")
-        configFile.writeText(
-            """
-        {
-            "allowList": {
-                "ios": ["react-native-reanimated"]
-            }
-        }
-        """.trimIndent(),
-        )
-        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
-
-        // When
-        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
-
-        // Then
-        assertThat(extension.allowList).isNull()
-    }
-
-    @Test
-    fun `loadDenyList should set allowList to empty set when android key is explicitly empty`() {
-        // Given
-        val extension = PackagesManager()
-        val configFile = File(tempDir, "rnrepo.config.json")
-        configFile.writeText(
-            """
-        {
-            "allowList": {
-                "android": []
-            }
-        }
-        """.trimIndent(),
-        )
-        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
-
-        // When
-        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
-
-        // Then
-        assertThat(extension.allowList).isNotNull().isEmpty()
     }
 
     @Test
@@ -440,81 +462,6 @@ class PrebuildsPluginHelperMethodsTest {
         assertThat(appMatchesAppProject).isTrue()
         assertThat(appMatchesAppCheckModule).isFalse()
         assertThat(appCheckMatchesAppCheckModule).isTrue()
-    }
-
-    @Test
-    fun `isPackageAllowed should return true when allowList is null`() {
-        // Given
-        val extension = PackagesManager() // allowList defaults to null
-
-        // When
-        val result = invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageAllowed",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-reanimated",
-            extension,
-        )
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `isPackageAllowed should return true for packages in the allowList`() {
-        // Given
-        val extension = PackagesManager()
-        extension.allowList = setOf("react-native-reanimated", "react-native-screens")
-
-        // When
-        val result = invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageAllowed",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-reanimated",
-            extension,
-        )
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `isPackageAllowed should return false for packages not in the allowList`() {
-        // Given
-        val extension = PackagesManager()
-        extension.allowList = setOf("react-native-reanimated")
-
-        // When
-        val result = invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageAllowed",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-screens",
-            extension,
-        )
-
-        // Then
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `isPackageAllowed should return false for all packages when allowList is empty`() {
-        // Given
-        val extension = PackagesManager()
-        extension.allowList = emptySet()
-
-        // When
-        val result = invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageAllowed",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-reanimated",
-            extension,
-        )
-
-        // Then
-        assertThat(result).isFalse()
     }
 
     @Test
@@ -706,31 +653,58 @@ class PrebuildsPluginHelperMethodsTest {
     }
 
     @Test
-    fun `denyList should take precedence over allowList`() {
+    fun `loadDenyList should throw when both denyList and allowList are configured`() {
         // Given
         val extension = PackagesManager()
-        extension.denyList = setOf("react-native-reanimated")
-        extension.allowList = setOf("react-native-reanimated")
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+            {
+                "denyList": {
+                    "android": ["react-native-vector-icons"]
+                },
+                "allowList": {
+                    "android": ["react-native-reanimated"]
+                }
+            }
+            """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
+
+        // When / Then
+        assertThatThrownBy {
+            invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
+        }.hasCauseInstanceOf(GradleException::class.java)
+            .cause()
+            .hasMessageContaining("Both 'denyList' and 'allowList'")
+
+        assertThat(extension.denyList).isEmpty()
+    }
+
+    @Test
+    fun `loadDenyList should not throw when allowList and denyList target different platforms`() {
+        // Given an allowList for iOS and a denyList for Android (different platforms)
+        val extension = PackagesManager()
+        val configFile = File(tempDir, "rnrepo.config.json")
+        configFile.writeText(
+            """
+            {
+                "denyList": {
+                    "android": ["react-native-vector-icons"]
+                },
+                "allowList": {
+                    "ios": ["react-native-reanimated"]
+                }
+            }
+            """.trimIndent(),
+        )
+        setPrivateField(plugin, "REACT_NATIVE_ROOT_DIR", tempDir)
 
         // When
-        val isDenied = !invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageNotDenied",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-reanimated",
-            extension,
-        )
-        val isAllowed = invokePrivateMethod<Boolean>(
-            plugin,
-            "isPackageAllowed",
-            arrayOf(String::class.java, PackagesManager::class.java),
-            "react-native-reanimated",
-            extension,
-        )
+        invokePrivateMethod<Unit>(plugin, "loadDenyList", arrayOf(PackagesManager::class.java), extension)
 
-        // Then
-        assertThat(isDenied).isTrue()
-        assertThat(isAllowed).isTrue() // allowList passes, but denyList wins upstream in checkIfPackageIsSupported
+        // Then the Android denyList is applied and no exception is thrown
+        assertThat(extension.denyList).containsExactly("react-native-vector-icons")
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## 📝 Description

Adding `allowList` support to both the Android Gradle plugin and iOS CocoaPods plugin as a complement to the existing `denyList`.

When a project has many dependencies but only wants a subset prebuilt, `denyList` required listing every excluded package manually. The new `allowList` lets users opt into a smaller set instead, and anything not on the list falls through to building from source.

The `allowList` also serves as an opt-in mechanism. Without it, any library you already depend on that becomes newly available on the RNRepo Maven repository will automatically start being pulled as a prebuild on the next build. The `allowList` gives teams a way to control exactly which libraries use prebuilt artifacts, allowing them to verify and explicitly approve each one before it is adopted.

When `allowList` is absent or the platform key is missing, the value is `null` and all packages remain eligible (existing behaviour preserved). If both `allowList` and `denyList` are set, (OLD: `denyList` takes precedence.,) EDIT: plugins throw error - only one list can be set at the time

Updated `rnrepo.config.json` documentation in the main README.

[hidden-comment]: <> (Update changelog if needed)
[hidden-comment]: <> (Mention related issues if applicable)
[hidden-comment]: <> (To trigger the regression build tests, add `build-android`/`build-ios`/`build-expo` labels to the pull request)

Closes #374  

## 🧪 Testing

9 unit tests added to `PrebuildsPluginHelperMethodsTest` covering all `allowList` scenarios (29/29 passing).

For manual verification:

**Steps to reproduce:**
1. Add `rnrepo.config.json` to your project root with `allowList` containing one known package for your platform
2. Run `./gradlew app:assembleDebug` (Android) or `pod install` (iOS)
3. Confirm only the listed package appears in the prebuilt summary and all others appear under denied/source-build output
4. Remove the `allowList` key entirely and rebuild to confirm all packages are prebuilt as before
5. Set `allowList` and `denyList` to the same package and rebuild to confirm `denyList` wins

### Testing_2

ANDROID
- baseline (no config)
  - ```
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-reanimated@4.2.1-worklets0.7.1
      - 📦 react-native-safe-area-context@5.8.0
      - 📦 react-native-worklets@0.7.1
    ```
- deny list (react-native-safe-area-context)
  - ```
    [📦 RNRepo] Loaded deny list from config: [react-native-safe-area-context]
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-reanimated@4.2.1-worklets0.7.1
      - 📦 react-native-worklets@0.7.1
    ```
- allow list (react-native-safe-area-context)
  - ```
    [📦 RNRepo] Loaded allow list from config: [react-native-safe-area-context]. Denying all other packages: [react-native-reanimated, react-native-worklets]
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-safe-area-context@5.8.0
    ```
- deny[android] and allow[ios] lists (android: react-native-safe-area-context)
  - ```
    [📦 RNRepo] Loaded allow list from config: [react-native-safe-area-context]. Denying all other packages: [react-native-reanimated, react-native-worklets]
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-safe-area-context@5.8.0
    ```
- deny[android] and allow[android] lists 
  - ```
    > Failed to apply plugin 'org.rnrepo.tools.prebuilds-plugin'.
    > [RNRepo] Both 'denyList' and 'allowList' are configured for Android in rnrepo.config.json. Please use only one of them.
    ```

iOS
- baseline (no config)
  - ```
    [📦 RNRepo] 3/3 dependencies (100.0%) using pre-built frameworks! 🎉
    ```
- deny list (react-native-safe-area-context)
  - ```
    [📦 RNRepo] ⬇ Downloaded from Maven (2):
    [📦 RNRepo]   • RNWorklets
    [📦 RNRepo]   • RNReanimated
    [📦 RNRepo] ⊘ Denied from pre-builds (1):
    [📦 RNRepo]   • react-native-safe-area-context
    ```
- allow list (react-native-safe-area-context)
  - ```
    [📦 RNRepo] ⬇ Downloaded from Maven (1):
    [📦 RNRepo]   • react-native-safe-area-context
    [📦 RNRepo] ⊘ Denied from pre-builds (2):
    [📦 RNRepo]   • RNReanimated
    [📦 RNRepo]   • RNWorklets
    ```
- deny[android] and allow[ios] lists (ios: react-native-safe-area-context)
  - ```
    [📦 RNRepo] ⬇ Downloaded from Maven (1):
    [📦 RNRepo]   • react-native-safe-area-context
    [📦 RNRepo] ⊘ Denied from pre-builds (2):
    [📦 RNRepo]   • RNReanimated
    [📦 RNRepo]   • RNWorklets
    ```
- deny[ios] and allow[ios] lists 
  - ```
    RuntimeError - RNRepo: Both 'denyList' and 'allowList' are configured for iOS in rnrepo.config.json. Please use only one of them.
    ```
