### PR TITLE
Fix RNRepo prebuild substitution prefix matching

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix Android substitution prefix matching (#385)
+
 ## [0.1.5] - 2026-06-12
 
 ### Changed

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -7,6 +7,9 @@ import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.logging.Logger
@@ -128,7 +131,7 @@ class PrebuildsPlugin : Plugin<Project> {
                             evaluatedProject.configurations.all { config ->
                                 config.resolutionStrategy.dependencySubstitution { substitutions ->
                                     substitutions.all { dependencySubstitution ->
-                                        if (dependencySubstitution.requested.displayName.contains("${packageItem.name}")) {
+                                        if (matchesPackageSelector(dependencySubstitution.requested, packageItem)) {
                                             dependencySubstitution.useTarget(substitutions.module(module))
                                             dependencySubstitution.artifactSelection {
                                                 it.selectArtifact(
@@ -177,6 +180,16 @@ class PrebuildsPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun matchesPackageSelector(
+        requested: ComponentSelector,
+        packageItem: PackageItem,
+    ): Boolean =
+        when (requested) {
+            is ProjectComponentSelector -> requested.projectPath == ":${packageItem.name}"
+            is ModuleComponentSelector -> requested.module == packageItem.name
+            else -> requested.displayName == packageItem.name
+        }
 
     private fun addRNRepoRepository(project: Project) {
         val rnrepoUrl = project.uri("https://packages.rnrepo.org/releases")

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -5,6 +5,9 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.logging.Logger
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -277,6 +280,71 @@ class PrebuildsPluginHelperMethodsTest {
         // Then
         assertThat(result1).isFalse()
         assertThat(result2).isTrue()
+    }
+
+    @Test
+    fun `matchesPackageSelector should not match package name prefixes`() {
+        // Given
+        val appPackage = PackageItem("react-native-firebase_app", "23.8.8", "@react-native-firebase/app")
+        val appCheckPackage = PackageItem("react-native-firebase_app-check", "23.8.8", "@react-native-firebase/app-check")
+
+        val appCheckProjectSelector = mockk<ProjectComponentSelector>()
+        every { appCheckProjectSelector.projectPath } returns ":react-native-firebase_app-check"
+
+        val appProjectSelector = mockk<ProjectComponentSelector>()
+        every { appProjectSelector.projectPath } returns ":react-native-firebase_app"
+
+        val appCheckModuleSelector = mockk<ModuleComponentSelector>()
+        every { appCheckModuleSelector.module } returns "react-native-firebase_app-check"
+
+        // When
+        val appMatchesAppCheckProject =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "matchesPackageSelector",
+                arrayOf(ComponentSelector::class.java, PackageItem::class.java),
+                appCheckProjectSelector,
+                appPackage,
+            )
+        val appCheckMatchesAppCheckProject =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "matchesPackageSelector",
+                arrayOf(ComponentSelector::class.java, PackageItem::class.java),
+                appCheckProjectSelector,
+                appCheckPackage,
+            )
+        val appMatchesAppProject =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "matchesPackageSelector",
+                arrayOf(ComponentSelector::class.java, PackageItem::class.java),
+                appProjectSelector,
+                appPackage,
+            )
+        val appMatchesAppCheckModule =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "matchesPackageSelector",
+                arrayOf(ComponentSelector::class.java, PackageItem::class.java),
+                appCheckModuleSelector,
+                appPackage,
+            )
+        val appCheckMatchesAppCheckModule =
+            invokePrivateMethod<Boolean>(
+                plugin,
+                "matchesPackageSelector",
+                arrayOf(ComponentSelector::class.java, PackageItem::class.java),
+                appCheckModuleSelector,
+                appCheckPackage,
+            )
+
+        // Then
+        assertThat(appMatchesAppCheckProject).isFalse()
+        assertThat(appCheckMatchesAppCheckProject).isTrue()
+        assertThat(appMatchesAppProject).isTrue()
+        assertThat(appMatchesAppCheckModule).isFalse()
+        assertThat(appCheckMatchesAppCheckModule).isTrue()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix RNRepo prebuild dependency substitution so package names are matched exactly instead of by substring.

This prevents packages with shared Gradle-name prefixes from being substituted to the wrong prebuilt artifact. One concrete case is React Native Firebase: `react-native-firebase_app` and `react-native-firebase_app-check`.

## Context

RNRepo’s Gradle plugin substitutes supported React Native library projects with prebuilt RNRepo artifacts. The previous matching condition used `dependencySubstitution.requested.displayName.contains(packageItem.name)`

This is too broad for package names where one Gradle project name is a prefix of another.

For example, when `@react-native-firebase/app-check` is autolinked, React Native correctly generates a `PackageList.java` entry for `io.invertase.firebase.appcheck.ReactNativeFirebaseAppCheckPackage`

But if Gradle resolves `:react-native-firebase_app-check` to `org.rnrepo.public:react-native-firebase_app`, that will of course be incorrect and the compile classpath won't contain the App Check package class, and Android compilation fails with:

`PackageList.java: error: package io.invertase.firebase.appcheck does not exist`

The issue can appear project-dependent because supportedPackages is collected through parallel package checks into a concurrent set, so iteration order depends on the project’s package set. If the app-check substitution is added first and the broader app rule runs later, the later substring match can overwrite the App Check substitution.

## Reproduction

Minimal reproduction repo:

[pawicao/rnrepo-firebase](https://github.com/pawicao/rnrepo-firebase)

Useful command:
```
cd android
./gradlew :app:dependencyInsight --configuration debugCompileClasspath --dependency react-native-firebase_app-check
```
Before this fix, the dependency insight output shows App Check being rewritten to Firebase App:

```
project :react-native-firebase_app-check -> org.rnrepo.public:react-native-firebase_app:23.8.8
org.rnrepo.public:react-native-firebase_app-check:23.8.8 -> org.rnrepo.public:react-native-firebase_app:23.8.8
```

And compilation fails with:

```
./gradlew :app:compileDebugJavaWithJavac

PackageList.java: error: package io.invertase.firebase.appcheck does not exist
```

## Fix

This PR introduces a fix that changes substitution matching to use exact Gradle selector data where available:

- `ProjectComponentSelector.projectPath == ":${packageItem.name}"`
- `ModuleComponentSelector.module == packageItem.name`
- exact `displayName` fallback for other selector types

This keeps the existing substitution behavior but removes prefix collisions and order sensitivity for similarly named packages.

## Tests

Added a regression test covering the `react-native-firebase_app` / `react-native-firebase_app-check` prefix collision.

Verified with:

```
./packages/build-tools/gradle-plugin/gradlew -p packages/build-tools/gradle-plugin test --info --no-daemon
./packages/build-tools/gradle-plugin/gradlew -p packages/build-tools/gradle-plugin spotlessCheck -q --no-daemon
```

Also verified locally against the repro that the patched plugin resolves App Check correctly:
```
project :react-native-firebase_app-check -> org.rnrepo.public:react-native-firebase_app-check:23.8.8
```