### PR TITLE
support licenses in other SPDX format

### DIFF
--- a/packages/builder/build-library-android.ts
+++ b/packages/builder/build-library-android.ts
@@ -53,7 +53,7 @@ try {
   process.exit(1);
 }
 
-async function buildAAR(appDir: string, license: AllowedLicense) {
+async function buildAAR(appDir: string, license: AllowedLicense[]) {
   const gradleProjectName = sanitizePackageName(libraryName);
   const classifier = `rn${reactNativeVersion}${
     workletsVersion ? `-worklets${workletsVersion}` : ''
@@ -118,8 +118,9 @@ async function buildAAR(appDir: string, license: AllowedLicense) {
       `-PrnrepoClassifier=${classifier}`,
       `-PrnrepoCpuInfo=${getCpuInfo()}`,
       `-PrnrepoBuildUrl=${GITHUB_BUILD_URL}`,
-      `-PrnrepoLicenseName=${license}`,
-      `-PrnrepoLicenseUrl=https://opensource.org/license/${license}`,
+      // Comma-separated list of SPDX license ids; the publishing init script
+      // emits one <license> POM node per entry, deriving the url from the name.
+      `-PrnrepoLicenseName=${license.join(',')}`,
     ];
     await $`./gradlew ${args}`.cwd(androidPath);
 

--- a/packages/builder/build-library-ios.ts
+++ b/packages/builder/build-library-ios.ts
@@ -134,7 +134,7 @@ async function xcodebuild(
 /**
  * Build the iOS XCFramework
  */
-async function buildFramework(appDir: string, _license: AllowedLicense) {
+async function buildFramework(appDir: string, _license: AllowedLicense[]) {
   const iosPath = join(appDir, 'ios');
   const projectPath = join(iosPath, basename(appDir) + '.xcworkspace');
 

--- a/packages/builder/build-utils.ts
+++ b/packages/builder/build-utils.ts
@@ -131,21 +131,47 @@ function getLibraryLicenseConfig(libraryName: string): Record<string, string> | 
 }
 
 /**
- * Extract and verify the library's license
- * Checks against ALLOWED_LICENSES, or verifies MD5 hash if configured in libraries.json
+ * Parse an SPDX-style license expression into individual license identifiers.
+ *
+ * Supports a single license (e.g. "MIT") or a conjunction of licenses with
+ * optional surrounding parentheses (e.g. "(MIT AND BSD-3-Clause)"). The "AND"
+ * separator is matched case-insensitively. Returns the trimmed, non-empty parts.
+ */
+function parseLicenseExpression(licenseField: string): string[] {
+  const stripped = licenseField
+    .trim()
+    .replace(/^\(/, '')
+    .replace(/\)$/, '')
+    .trim();
+  return stripped
+    .split(/\s+AND\s+/i)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Extract and verify the library's license(s)
+ * Checks against ALLOWED_LICENSES (supporting SPDX "(<l1> AND <l2>)"
+ * expressions), or verifies MD5 hash if configured in libraries.json
  */
 export function extractAndVerifyLicense(
   appDir: string,
   libraryName: string
-): AllowedLicense {
+): AllowedLicense[] {
   const packageDir = join(appDir, 'node_modules', libraryName);
   const packageJsonPath = join(packageDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   const licenseField = packageJson.license;
 
-  // Check if license is in allowed list
-  if (ALLOWED_LICENSES.includes(licenseField as AllowedLicense)) {
-    return licenseField as AllowedLicense;
+  // Check if every license in the expression is in the allowed list
+  const parsedLicenses = parseLicenseExpression(licenseField);
+  if (
+    parsedLicenses.length > 0 &&
+    parsedLicenses.every((license) =>
+      ALLOWED_LICENSES.includes(license as AllowedLicense)
+    )
+  ) {
+    return parsedLicenses as AllowedLicense[];
   }
 
   // Try to verify by MD5 hash if configured in libraries.json
@@ -169,7 +195,7 @@ export function extractAndVerifyLicense(
     licenseConfig.fileMD5,
     libraryName
   );
-  return licenseConfig.type as AllowedLicense;
+  return [licenseConfig.type as AllowedLicense];
 }
 
 /**
@@ -285,7 +311,7 @@ export async function setupReactNativeProject(
   workletsVersion: string | undefined
 ): Promise<{
   appDir: string;
-  license: AllowedLicense;
+  license: AllowedLicense[];
   postinstallGradleScriptPath?: string;
 }> {
   const appDir = join(workDir, 'rnrepo_build_app');

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -76,9 +76,22 @@ gradle.projectsEvaluated {
                                     }
                                 }
                                 licenses {
-                                    license {
-                                        name = project.findProperty('rnrepoLicenseName')
-                                        url = project.findProperty('rnrepoLicenseUrl')
+                                    // rnrepoLicenseName is a comma-separated list of SPDX
+                                    // license ids (e.g. "MIT" or "MIT,BSD-3-Clause" for an
+                                    // SPDX "(MIT AND BSD-3-Clause)" expression). Emit one
+                                    // <license> node per entry.
+                                    def licenseSpec = delegate
+                                    def licenseNames = project.findProperty('rnrepoLicenseName')
+                                    if (licenseNames != null) {
+                                        licenseNames.toString().split(',').each { rawName ->
+                                            def licenseName = rawName.trim()
+                                            if (licenseName) {
+                                                licenseSpec.license { lic ->
+                                                    lic.name = licenseName
+                                                    lic.url = "https://opensource.org/license/${licenseName}"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## 📝 Description

Allow libs with license format `(<l1> AND <l2>)` to be builded (mmkv had that case)
- checks license field in package.json (like previously)
- if grep (<l1> AND <l2>)
  - checks if both licenses are supported
    - it true, then builds and adds to .pom file both licenses 

I haven't used any npm package for SPDX format validation or implemented handling for all possible SPDX formats, as there was no need for it in the current situation (one package was the only problem). If this becomes an issue later, we can consider introducing a more comprehensive solution.

#379

## 🧪 Testing

before
```
error: License (MIT AND BSD-3-Clause) is not allowed for react-native-mmkv. Allowed licenses are: MIT, Apache-2.0, BSD-3-Clause, BSD-3-Clause-Clear, BSD-2-Clause. You can configure a custom license with MD5 hash verification in libraries.json.
```
after
```
✅ Successfully built AAR for react-native-mmkv@3.3.0 with RN 0.83.0
```