### PR TITLE
Support new libs

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -981,5 +981,20 @@
         "publishedAfterDate": "2020-01-01"
       }
     ]
+  },
+  "react-native-keep-awake": {
+    "postInstallScriptPath": "postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts",
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2016-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2016-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -488,6 +488,12 @@
         "versionMatcher": "*",
         "publishedAfterDate": "2025-01-01"
       }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
     ]
   },
   "react-native-haptic-feedback": {

--- a/libraries.json
+++ b/libraries.json
@@ -953,5 +953,19 @@
         "publishedAfterDate": "2020-01-01"
       }
     ]
+  },
+  "react-native-image-crop-picker": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -939,5 +939,19 @@
         "publishedAfterDate": "2025-01-01"
       }
     ]
+  },
+  "react-native-biometrics": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2020-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2020-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -191,16 +191,17 @@
     ]
   },
   "@react-native-community/netinfo": {
+    "weeklyDownloadsThreshold": 30000,
     "android": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
+        "publishedAfterDate": "2020-01-01"
       }
     ],
     "ios": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
+        "publishedAfterDate": "2020-01-01"
       }
     ]
   },

--- a/libraries.json
+++ b/libraries.json
@@ -967,5 +967,19 @@
         "publishedAfterDate": "2025-01-01"
       }
     ]
+  },
+  "@notifee/react-native": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2020-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2020-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -996,5 +996,19 @@
         "publishedAfterDate": "2016-01-01"
       }
     ]
+  },
+  "react-native-audio-record": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2018-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2018-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -909,5 +909,19 @@
         "publishedAfterDate": "2025-01-01"
       }
     ]
+  },
+  "react-native-quick-crypto": {
+    "android": [
+      {
+        "versionMatcher": "<1.0.0",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "<1.0.0",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -925,5 +925,19 @@
         "publishedAfterDate": "2025-01-01"
       }
     ]
+  },
+  "@react-native-community/checkbox": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -692,6 +692,12 @@
         "versionMatcher": "*",
         "publishedAfterDate": "2025-01-01"
       }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
     ]
   },
   "@ua/react-native-airship": {

--- a/libraries.json
+++ b/libraries.json
@@ -1025,5 +1025,19 @@
         "publishedAfterDate": "2023-01-01"
       }
     ]
+  },
+  "react-native-calendar-events": {
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2023-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2023-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -813,6 +813,12 @@
         "versionMatcher": "<4.0.0",
         "publishedAfterDate": "2025-01-01"
       }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "<4.0.0",
+        "publishedAfterDate": "2025-01-01"
+      }
     ]
   },
   "react-native-edge-to-edge": {

--- a/libraries.json
+++ b/libraries.json
@@ -1010,5 +1010,20 @@
         "publishedAfterDate": "2018-01-01"
       }
     ]
+  },
+  "react-native-add-calendar-event": {
+    "postInstallScriptPath": "postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts",
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2023-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2023-01-01"
+      }
+    ]
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -195,13 +195,13 @@
     "android": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "publishedAfterDate": "2023-01-01"
       }
     ],
     "ios": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "publishedAfterDate": "2023-01-01"
       }
     ]
   },
@@ -943,18 +943,17 @@
   "react-native-biometrics": {
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "versionMatcher": "3.0.1"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "versionMatcher": "3.0.1"
       }
     ]
   },
   "react-native-image-crop-picker": {
+    "weeklyDownloadsThreshold": 20000,
     "android": [
       {
         "versionMatcher": "*",
@@ -971,14 +970,12 @@
   "@notifee/react-native": {
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "versionMatcher": ["9.1.8", "9.0.2"]
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2020-01-01"
+        "versionMatcher": ["9.1.8", "9.0.2"]
       }
     ]
   },
@@ -986,28 +983,24 @@
     "postInstallScriptPath": "postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts",
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2016-01-01"
+        "versionMatcher": "4.0.0"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2016-01-01"
+        "versionMatcher": "4.0.0"
       }
     ]
   },
   "react-native-audio-record": {
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2018-01-01"
+        "versionMatcher": "0.2.2"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2018-01-01"
+        "versionMatcher": "0.2.2"
       }
     ]
   },
@@ -1015,28 +1008,24 @@
     "postInstallScriptPath": "postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts",
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2023-01-01"
+        "versionMatcher": ["5.0.0", "4.2.2"]
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2023-01-01"
+        "versionMatcher": ["5.0.0", "4.2.2"]
       }
     ]
   },
   "react-native-calendar-events": {
     "android": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2023-01-01"
+        "versionMatcher": "2.2.0"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
-        "publishedAfterDate": "2023-01-01"
+        "versionMatcher": "2.2.0"
       }
     ]
   }

--- a/libraries.json
+++ b/libraries.json
@@ -823,16 +823,17 @@
     ]
   },
   "react-native-vector-icons": {
+    "weeklyDownloadsThreshold": 30000,
     "android": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
+        "publishedAfterDate": "2020-01-01"
       }
     ],
     "ios": [
       {
         "versionMatcher": "*",
-        "publishedAfterDate": "2025-01-01"
+        "publishedAfterDate": "2020-01-01"
       }
     ]
   },

--- a/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
+++ b/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
-export default async function preInstallSetup(): Promise<void> {
-    console.log(`Running pre-install setup for react-native-add-calendar-event...`);
+export default async function postInstallSetup(): Promise<void> {
+    console.log(`Running post-install setup for react-native-add-calendar-event...`);
     
     // change jcenter() to mavenCentral() in node_modules/react-native-add-calendar-event/android/build.gradle
     const filePath = 'node_modules/react-native-add-calendar-event/android/build.gradle';
@@ -12,12 +12,12 @@ export default async function preInstallSetup(): Promise<void> {
         fs.writeFileSync(filePath, content, 'utf8');
     }
     
-    console.log(`✓ Pre-install setup for react-native-add-calendar-event completed.`);
+    console.log(`✓ Post-install setup for react-native-add-calendar-event completed.`);
 };
 
 try {
-    await preInstallSetup();
+    await postInstallSetup();
 } catch (error) {
-    console.error('Error during pre-install setup:', error);
+    console.error('Error during post-install setup:', error);
     throw error;
 }

--- a/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
+++ b/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
@@ -1,0 +1,24 @@
+import { $ } from 'bun';
+import fs from 'fs';
+
+export default async function preInstallSetup(): Promise<void> {
+    console.log(`Running pre-install setup for react-native-add-calendar-event...`);
+    
+    // change jcenter() to mavenCentral() in node_modules/react-native-add-calendar-event/android/build.gradle
+    const filePath = 'node_modules/react-native-add-calendar-event/android/build.gradle';
+    
+    if (fs.existsSync(filePath)) {
+        let content = fs.readFileSync(filePath, 'utf8');
+        content = content.replace(/jcenter\(\)/g, 'mavenCentral()');
+        fs.writeFileSync(filePath, content, 'utf8');
+    }
+    
+    console.log(`✓ Pre-install setup for react-native-add-calendar-event completed.`);
+};
+
+try {
+    await preInstallSetup();
+} catch (error) {
+    console.error('Error during pre-install setup:', error);
+    throw error;
+}

--- a/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
+++ b/postInstallScripts/react-native-add-calendar-event/react-native-add-calendar-event.ts
@@ -1,4 +1,3 @@
-import { $ } from 'bun';
 import fs from 'fs';
 
 export default async function preInstallSetup(): Promise<void> {

--- a/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
+++ b/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
-export default async function preInstallSetup(): Promise<void> {
-    console.log(`Running pre-install setup for react-native-keep-awake...`);
+export default async function postInstallSetup(): Promise<void> {
+    console.log(`Running post-install setup for react-native-keep-awake...`);
     
     // change jcenter() to mavenCentral() in node_modules/react-native-keep-awake/android/build.gradle
     const filePath = 'node_modules/react-native-keep-awake/android/build.gradle';
@@ -12,12 +12,12 @@ export default async function preInstallSetup(): Promise<void> {
         fs.writeFileSync(filePath, content, 'utf8');
     }
     
-    console.log(`✓ Pre-install setup for react-native-keep-awake completed.`);
+    console.log(`✓ Post-install setup for react-native-keep-awake completed.`);
 };
 
 try {
-    await preInstallSetup();
+    await postInstallSetup();
 } catch (error) {
-    console.error('Error during pre-install setup:', error);
+    console.error('Error during post-install setup:', error);
     throw error;
 }

--- a/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
+++ b/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
@@ -1,0 +1,24 @@
+import { $ } from 'bun';
+import fs from 'fs';
+
+export default async function preInstallSetup(): Promise<void> {
+    console.log(`Running pre-install setup for react-native-keep-awake...`);
+    
+    // change jcenter() to mavenCentral() in node_modules/react-native-keep-awake/android/build.gradle
+    const filePath = 'node_modules/react-native-keep-awake/android/build.gradle';
+    
+    if (fs.existsSync(filePath)) {
+        let content = fs.readFileSync(filePath, 'utf8');
+        content = content.replace(/jcenter\(\)/g, 'mavenCentral()');
+        fs.writeFileSync(filePath, content, 'utf8');
+    }
+    
+    console.log(`✓ Pre-install setup for react-native-keep-awake completed.`);
+};
+
+try {
+    await preInstallSetup();
+} catch (error) {
+    console.error('Error during pre-install setup:', error);
+    throw error;
+}

--- a/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
+++ b/postInstallScripts/react-native-keep-awake/react-native-keep-awake.ts
@@ -1,4 +1,3 @@
-import { $ } from 'bun';
 import fs from 'fs';
 
 export default async function preInstallSetup(): Promise<void> {


### PR DESCRIPTION
## 📝 Description

Added support for:
- react-native-quick-crypto
  - https://www.npmjs.com/package/react-native-quick-crypto?activeTab=versions
  - only for <1.0.0 since later versions uses nitro
  - #382
- @sentry/react-native
  - https://www.npmjs.com/package/@sentry/react-native?activeTab=versions
  - ios added, android existed
  - #381
- @react-native-google-signin/google-signin
  - https://www.npmjs.com/package/@react-native-google-signin/google-signin?activeTab=versions
  - ios added, android existed
  - #380
- react-native-vector-icons@10.2.0
  - https://www.npmjs.com/package/react-native-vector-icons?activeTab=versions
  - #363
- @react-native-community/netinfo@11.4.1
  - https://www.npmjs.com/package/@react-native-community/netinfo?activeTab=versions
  - added ios and changed date to build 11.4.1 (+1M downl) 
  - #363
- @react-native-community/checkbox@0.5.20
  - https://www.npmjs.com/package/@react-native-community/checkbox?activeTab=versions
  - #363
- react-native-biometrics@3.0.1
  - https://www.npmjs.com/package/react-native-biometrics?activeTab=versions
  - only 1 version have matched threshold
  - not updated for 4y
  - #363
- react-native-image-crop-picker@0.51.0
  - https://www.npmjs.com/package/react-native-image-crop-picker?activeTab=versions
  - #363
- @notifee/react-native@9.1.8
  - https://www.npmjs.com/package/@notifee/react-native?activeTab=versions
  - only 2 versions have matched threshold
  - not updated for 2y
  - #363
- react-native-keep-awake@4.0.0
  - https://www.npmjs.com/package/react-native-keep-awake?activeTab=versions
  - only 4.0.0 have matched threshold
  - not updated for 8y
  - #363
- react-native-audio-record@0.2.2
  - https://www.npmjs.com/package/react-native-audio-record?activeTab=versions
  - only 0.2.2 have matched threshold
  - not updated for 7y
  - #363
- react-native-add-calendar-event@3.0.1
  - https://www.npmjs.com/package/react-native-add-calendar-event?activeTab=versions
  - only 5.0.0 and 4.2.2 have matched threshold
  - not updated for 2y
  - #363
- react-native-calendar-events@2.2.0
  - https://www.npmjs.com/package/react-native-calendar-events?activeTab=versions
  - only 2.2.0 version have +20k downloads, rest <1k
  - not updated for 5y
  - #363 

Note: some packages have hardcoded versions, because i dont think that packages not updated for few years would release new version - that sounds like security alert.

## 🧪 Testing

- react-native-quick-crypto
  - ```
    ✅ Successfully built AAR for react-native-quick-crypto@0.7.17 with RN 0.83.6
    ✅ Successfully built static XCFramework for react-native-quick-crypto@0.7.17 with RN 0.83.6
    ```
- @sentry/react-native
  - ```
    ✅ Successfully built static XCFramework for @sentry/react-native@8.14.0 with RN 0.85.0
    ```
- @react-native-google-signin/google-signin
  - ```
    ✅ Successfully built static XCFramework for @react-native-google-signin/google-signin@16.1.2 with RN 0.85.0
    ```
- react-native-vector-icons@10.2.0
  - already present in builds
- @react-native-community/netinfo@11.4.1
  - already present in builds
- @react-native-community/checkbox@0.5.20
  - ```
    ✅ Successfully built AAR for @react-native-community/checkbox@0.5.20 with RN 0.85.0
    ✅ Successfully built static XCFramework for @react-native-community/checkbox@0.5.20 with RN 0.85.0
    ```  
- react-native-biometrics@3.0.1
  - ```
    ✅ Successfully built static XCFramework for react-native-biometrics@3.0.1 with RN 0.85.0
    ✅ Successfully built AAR for react-native-biometrics@3.0.1 with RN 0.85.0
    ```
- react-native-image-crop-picker@0.51.0
  - ```
    ✅ Successfully built AAR for react-native-image-crop-picker@0.51.0 with RN 0.85.0
    ✅ Successfully built static XCFramework for react-native-image-crop-picker@0.51.0 with RN 0.85.0
    ```
- @notifee/react-native@9.1.8
  - ```
    ✅ Successfully built AAR for @notifee/react-native@9.1.8 with RN 0.85.0
    ✅ Successfully built static XCFramework for @notifee/react-native@9.1.8 with RN 0.85.0
    ```
- react-native-keep-awake@4.0.0
  - ```
    ✅ Successfully built AAR for react-native-keep-awake@4.0.0 with RN 0.85.0
    ✅ Successfully built static XCFramework for react-native-keep-awake@4.0.0 with RN 0.85.0
    ```
- react-native-audio-record@0.2.2
  - ```
    ✅ Successfully built AAR for react-native-audio-record@0.2.2 with RN 0.85.0
    ✅ Successfully built static XCFramework for react-native-audio-record@0.2.2 with RN 0.85.0
    ```
- react-native-add-calendar-event@3.0.1
  - ```
    ✅ Successfully built AAR for react-native-add-calendar-event@3.0.1 with RN 0.85.0
    ✅ Successfully built static XCFramework for react-native-add-calendar-event@3.0.1 with RN 0.85.0
    ```
- react-native-calendar-events@2.2.0
  - ```
    ✅ Successfully built AAR for react-native-calendar-events@2.2.0 with RN 0.85.0
    ✅ Successfully built static XCFramework for react-native-calendar-events@2.2.0 with RN 0.85.0
    ```
