### PR TITLE
find podspec via `npx react-native config`

### DIFF
--- a/packages/builder/build-library-ios.ts
+++ b/packages/builder/build-library-ios.ts
@@ -64,15 +64,40 @@ try {
  * Get the pod name for a given library
  * This extracts the pod name from the library's podspec or package.json
  */
-function getPodName(appDir: string): string {
+async function getPodName(appDir: string): Promise<string> {
   const packagePath = join(appDir, 'node_modules', libraryName);
 
-  // Try to find podspec file using bun glob
+  // Find podspec with npx --no-install react-native config like RN does
+  try {
+    const configJson = await $`npx --no-install react-native config`
+      .cwd(appDir)
+      .quiet()
+      .text();
+    const config = JSON.parse(configJson);
+    const podspecPath: string | undefined =
+      config?.dependencies?.[libraryName]?.platforms?.ios?.podspecPath;
+    if (podspecPath) {
+      return basename(podspecPath, '.podspec');
+    }
+  } catch (error) {
+    console.warn(
+      `⚠️ Could not resolve pod name from \`react-native config\` for ${libraryName}, falling back to podspec glob:`,
+      error
+    );
+  }
+
+  // Try to find podspec file using bun glob as fallback
   const glob = new Glob('*.podspec');
   const podspecFiles = Array.from(glob.scanSync({ cwd: packagePath })) as string[];
 
   if (podspecFiles.length > 0) {
-    return basename(podspecFiles[0], '.podspec');
+    // same: https://github.com/react-native-community/cli/blob/9a25c5f/packages/cli-config-apple/src/config/findPodspec.ts
+    const packagePodspec = basename(packagePath) + '.podspec';
+    const podspecFile = podspecFiles.includes(packagePodspec)
+      ? packagePodspec
+      : podspecFiles[0];
+
+    return basename(podspecFile, '.podspec');
   }
 
   throw new Error(
@@ -143,7 +168,7 @@ async function buildFramework(appDir: string, _license: AllowedLicense) {
     throw new Error(`Xcode workspace not found at ${projectPath}`);
   }
 
-  const podName = getPodName(appDir);
+  const podName = await getPodName(appDir);
   console.log(
     `📱 Building library pod: ${podName}`
   );


### PR DESCRIPTION

## 📝 Description

RN does the same. This fixes `@notifee/react-native` ios building.

RCA was the `bun.Glob` that returns files in different order than `npx react-native config` so to make it reliable it will use same tools as RN project.

pod install output:
```
...
link_native_modules! {:ios_packages=>[{:configurations=>[], :name=>"@notifee/react-native", :root=>"/Users/radoslawrolka/rnrepo/temp_notifee_i_4/rnrepo_build_app/node_modules/@notifee/react-native", :path=>"../node_modules/@notifee/react-native", :podspec_path=>"/Users/radoslawrolka/rnrepo/temp_notifee_i_4/rnrepo_build_app/node_modules/@notifee/react-native/RNNotifee.podspec", :script_phases=>[]}], :ios_project_root_path=>"/Users/radoslawrolka/rnrepo/temp_notifee_i_4/rnrepo_build_app/ios", :react_native_path=>"../node_modules/react-native"}
Auto-linking React Native module for target `rnrepo_build_app`: RNNotifee
...
📱 Building library pod: RNNotifeeCore ### WRONG
...
```
error:
```
   stderr: "2026-06-19 14:15:27.758 xcodebuild[27136:15367734] Writing error result bundle to /var/folders/s6/sttzr99n3_l9fgg_zm9qkh1r0000gn/T/ResultBundle_2026-19-06_14-15-0027.xcresult\nxcodebuild: error: The workspace named \"rnrepo_build_app\" does not contain a scheme named \"RNNotifeeCore\". The \"-list\" option can be used to find the names of the schemes in the workspace.\n",
```

## 🧪 Testing
Now it finds properly the RNNotifee, not the RNNotifeeCore
```
bun run build-library-ios.ts @notifee/react-native 9.1.8 0.85.0 /tmp/temp_notifee
...
📱 Building library pod: RNNotifee
...
✅ Successfully built static XCFramework for @notifee/react-native@9.1.8 with RN 0.85.0
```