### PR TITLE
bump xcode 26.1 -> 26.3

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -5,7 +5,7 @@ inputs:
   xcode-version:
     description: 'Xcode version to use'
     required: false
-    default: '26.1'
+    default: '26.3'
   cocoapods-version:
     description: 'CocoaPods version to install'
     required: false


### PR DESCRIPTION
## 📝 Description

Upgrade Xcode if needed: Xcode 26.4 is required to compile a native iOS project. For EAS Build and Workflows, profiles without any specified image will default to Xcode 26.4.
- source: https://expo.dev/changelog/sdk-56#tool-version-bumps
- failed build: https://github.com/software-mansion/rnrepo/actions/runs/28091482981/job/83170331566
  - ```
    /Users/runner/work/rnrepo/rnrepo/expoExampleApp/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift:3:12: 
    error: 'weak' must be a mutable variable, because it may change at runtime
    weak let runtime: JavaScriptRuntime?
              ^
    ``` 
- But 26.4 is not yet available on setup-xcode GH action so im taking the latest 26.3, which also fixes the issue

## 🧪 Testing

- failed build: https://github.com/software-mansion/rnrepo/actions/runs/28091482981/job/83170331566
- passed build on this pr checks