### PR TITLE
bump versions before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Need RNRepo inside a private Maven, behind VPN, or mirrored into an internal art
 
 - ✅ Public beta with shared Maven repo.
 - ✅ iOS support in beta.
-- 🔜 Skip local codegen runs for libraries (will improve build times even more).
+- ✅ Skip local codegen runs for libraries (will improve build times even more).
 - 🔜 Expanded library coverage.
 - 🔜 Production release (general availability).
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/build-tools": {
       "name": "@rnrepo/build-tools",
-      "version": "0.1.6",
+      "version": "0.2.0",
     },
     "packages/builder": {
       "name": "@rnrepo/builder",
@@ -64,11 +64,11 @@
     },
     "packages/expo-config-plugin": {
       "name": "@rnrepo/expo-config-plugin",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@expo/config-plugins": "*",
         "@expo/config-types": "*",
-        "@rnrepo/build-tools": "0.1.6",
+        "@rnrepo/build-tools": "0.2.0",
       },
       "devDependencies": {
         "expo-module-scripts": "^5.0.7",

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [0.2.0] - 2026-07-03
 
 ### Added
 - Use prebuilded codegen in Android artifacts (#206)

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/build-tools",
   "title": "RNRepo Prebuilds plugin",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "RNRepo plugin for handling prebuilt binaries of iOS and Android libraries",
   "scripts": {
     "build": "./gradle-plugin/gradlew build --no-daemon -p gradle-plugin",

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-07-03
+
+### Changed
+- Bumped @rnrepo/build-tools dependency to 0.2.0 (#400)
+
 ## [0.3.3] - 2026-06-23
 
 ### Changed

--- a/packages/expo-config-plugin/package.json
+++ b/packages/expo-config-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/expo-config-plugin",
   "title": "RNRepo expo config plugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Plugin for configuring RNRepo prebuilt packages in Expo projects",
   "sideEffects": false,
   "main": "build/withRNRepoPlugin.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/config-plugins": "*",
     "@expo/config-types": "*",
-    "@rnrepo/build-tools": "0.1.6"
+    "@rnrepo/build-tools": "0.2.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"


### PR DESCRIPTION
## 📝 Description

Minor to 0.2.0 since this introduces the codegen usage for android packages
- @rnrepo/expo-config-plugin@0.3.4
- @rnrepo/build-tools@0.2.0
