### PR TITLE
fix ci example builds when 2 labels are added at the same time

### DIFF
--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -67,6 +67,7 @@ jobs:
         }}
     steps:
       - name: 🏗 Checkout repository
+        if: github.event_name == 'push' # workflow_dispatch has no changes, pr only looks on labels
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -43,17 +43,28 @@ env:
 
 jobs:
   check-changes:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios", "build-expo"]'), github.event.label.name))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       pull-requests: read
       contents: read
     outputs:
-      android: ${{ steps.filter.outputs.android }}
-      ios: ${{ steps.filter.outputs.ios }}
+      android: >-
+        ${{ (github.event_name == 'push' && steps.filter.outputs.android == 'true') || 
+            (github.event_name == 'workflow_dispatch' && inputs.request_android == true) || 
+            (github.event_name == 'pull_request' && !github.event.pull_request.draft && (
+              contains(github.event.pull_request.labels.*.name, 'build-android') || 
+              contains(github.event.pull_request.labels.*.name, 'build-expo')
+            )) 
+        }}
+      ios: >-
+        ${{ (github.event_name == 'push' && steps.filter.outputs.ios == 'true') || 
+            (github.event_name == 'workflow_dispatch' && inputs.request_ios == true) || 
+            (github.event_name == 'pull_request' && !github.event.pull_request.draft && (
+              contains(github.event.pull_request.labels.*.name, 'build-ios') || 
+              contains(github.event.pull_request.labels.*.name, 'build-expo')
+            )) 
+        }}
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -61,6 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: 🔍 Check for file changes
+        if: github.event_name == 'push' # workflow_dispatch has no changes, pr only looks on labels
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:
@@ -82,13 +94,7 @@ jobs:
 
   build-example-expo-app-android:
     needs: check-changes
-    if: >-
-      (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
-      (github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'build-android') ||
-        contains(github.event.pull_request.labels.*.name, 'build-expo')
-      ))
+    if: needs.check-changes.outputs.android == 'true'
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -144,13 +150,7 @@ jobs:
 
   build-example-expo-app-ios:
     needs: check-changes
-    if: >-
-      (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
-      (github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'build-ios') ||
-        contains(github.event.pull_request.labels.*.name, 'build-expo')
-      ))
+    if: needs.check-changes.outputs.ios == 'true'
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -43,6 +43,9 @@ env:
 
 jobs:
   check-changes:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios", "build-expo"]'), github.event.label.name))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -85,7 +85,10 @@ jobs:
     if: >-
       (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
-      (github.event_name == 'pull_request' && contains(fromJSON('["build-android", "build-expo"]'), github.event.label.name))
+      (github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.labels.*.name, 'build-android') ||
+        contains(github.event.pull_request.labels.*.name, 'build-expo')
+      ))
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -144,7 +147,10 @@ jobs:
     if: >-
       (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
-      (github.event_name == 'pull_request' && contains(fromJSON('["build-ios", "build-expo"]'), github.event.label.name))
+      (github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.labels.*.name, 'build-ios') ||
+        contains(github.event.pull_request.labels.*.name, 'build-expo')
+      ))
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -49,17 +49,22 @@ env:
 
 jobs:
   check-changes:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios"]'), github.event.label.name))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       pull-requests: read
       contents: read
     outputs:
-      android: ${{ steps.filter.outputs.android }}
-      ios: ${{ steps.filter.outputs.ios }}
+      android: >-
+        ${{ (github.event_name == 'push' && steps.filter.outputs.android == 'true') || 
+            (github.event_name == 'workflow_dispatch' && inputs.request_android == true) || 
+            (github.event_name == 'pull_request' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'build-android')) 
+        }}
+      ios: >-
+        ${{ (github.event_name == 'push' && steps.filter.outputs.ios == 'true') || 
+            (github.event_name == 'workflow_dispatch' && inputs.request_ios == true) || 
+            (github.event_name == 'pull_request' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'build-ios')) 
+        }}
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -67,6 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: 🔍 Check for file changes
+        if: github.event_name == 'push' # workflow_dispatch has no changes, pr only looks on labels
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:
@@ -86,10 +92,7 @@ jobs:
 
   build-example-rn-app-android:
     needs: check-changes
-    if: >-
-      (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-android'))
+    if: needs.check-changes.outputs.android == 'true'
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -137,10 +140,7 @@ jobs:
 
   build-example-rn-app-ios:
     needs: check-changes
-    if: >-
-      (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-ios'))
+    if: needs.check-changes.outputs.ios == 'true'
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -67,6 +67,7 @@ jobs:
         }}
     steps:
       - name: 🏗 Checkout repository
+        if: github.event_name == 'push' # workflow_dispatch has no changes, pr only looks on labels
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -49,6 +49,9 @@ env:
 
 jobs:
   check-changes:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!github.event.pull_request.draft && contains(fromJSON('["build-android", "build-ios"]'), github.event.label.name))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -89,7 +89,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && needs.check-changes.outputs.android == 'true') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.request_android == 'true') ||
-      (github.event_name == 'pull_request' && contains(fromJSON('["build-android"]'), github.event.label.name))
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-android'))
     runs-on: rnrepo-builder-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -140,7 +140,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && needs.check-changes.outputs.ios == 'true') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.request_ios == 'true') ||
-      (github.event_name == 'pull_request' && contains(fromJSON('["build-ios"]'), github.event.label.name))
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-ios'))
     runs-on: macos-latest-xlarge
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## 📝 Description

When 2 labels were added at same time ci ignored one of them because of only last even was processed so only one platform was launched.
```
... contains(fromJSON('["build-ios", "build-expo"]'), github.event.label.name)). 
                                                                   ^ only one label here
```

what changed:
- moved logic the checker job from build jobs
- changed inside "if" that decides to check if build given platform app:
  - ```
     - contains(fromJSON('["..."]'), github.event.label.name)) # this check only label in latest event
     + contains(github.event.pull_request.labels.*.name, 'build-...') # this checks all labels
     ```
  - `github.event.label.name` was kept in checker job to avoid triggering builds when other label is added, like "bug" etc

Logic stays the same and changes are only for pr checks for dev, not user-facing.