### PR TITLE
Revert "disable building screens until merging the fix (#405)"

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -261,7 +261,7 @@
     "preInstallScriptPath": "preInstallScripts/react-native-screens/react-native-screens.ts",
     "android": [
       {
-        "versionMatcher": ">=4.25.0",
+        "versionMatcher": ">4.25.0",
         "reactNativeVersion": ">=0.82.0",
         "publishedAfterDate": "2025-01-01"
       },

--- a/libraries.json
+++ b/libraries.json
@@ -261,7 +261,7 @@
     "preInstallScriptPath": "preInstallScripts/react-native-screens/react-native-screens.ts",
     "android": [
       {
-        "versionMatcher": ">4.25.0",
+        "versionMatcher": ">=4.25.0",
         "reactNativeVersion": ">=0.82.0",
         "publishedAfterDate": "2025-01-01"
       },
@@ -283,7 +283,7 @@
     ],
     "ios": [
       {
-        "versionMatcher": ">=4.25.0",
+        "versionMatcher": ">4.25.0",
         "reactNativeVersion": ">=0.82.0",
         "publishedAfterDate": "2025-01-01"
       },

--- a/libraries.json
+++ b/libraries.json
@@ -261,13 +261,45 @@
     "preInstallScriptPath": "preInstallScripts/react-native-screens/react-native-screens.ts",
     "android": [
       {
-        "versionMatcher": "*",
+        "versionMatcher": ">=4.25.0",
+        "reactNativeVersion": ">=0.82.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.19.0 <4.25.0",
+        "reactNativeVersion": ">=0.81.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.14.0 <4.19.0",
+        "reactNativeVersion": ">=0.79.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.9.0 <4.14.0",
+        "reactNativeVersion": ">=0.76.0",
         "publishedAfterDate": "2025-01-01"
       }
     ],
     "ios": [
       {
-        "versionMatcher": "*",
+        "versionMatcher": ">=4.25.0",
+        "reactNativeVersion": ">=0.82.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.19.0 <4.25.0",
+        "reactNativeVersion": ">=0.81.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.14.0 <4.19.0",
+        "reactNativeVersion": ">=0.79.0",
+        "publishedAfterDate": "2025-01-01"
+      },
+      {
+        "versionMatcher": ">=4.9.0 <4.14.0",
+        "reactNativeVersion": ">=0.76.0",
         "publishedAfterDate": "2025-01-01"
       }
     ]

--- a/libraries.json
+++ b/libraries.json
@@ -259,8 +259,18 @@
   },
   "react-native-screens": {
     "preInstallScriptPath": "preInstallScripts/react-native-screens/react-native-screens.ts",
-    "android": false,
-    "ios": false
+    "android": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ],
+    "ios": [
+      {
+        "versionMatcher": "*",
+        "publishedAfterDate": "2025-01-01"
+      }
+    ]
   },
   "react-native-worklets": {
     "android": [


### PR DESCRIPTION


## 📝 Description

This reverts commit 4bf26c483f99bcdf9279c28a0ca0f9632f2a3c9d.

reverts #405

versions used from: https://www.npmjs.com/package/react-native-screens#:~:text=x%20branch.-,Support%20for%20Fabric,-Fabric%20is%20React
