### PR TITLE
dont schedule libs newer than min-release-age

### DIFF
--- a/packages/scheduler/src/npm.ts
+++ b/packages/scheduler/src/npm.ts
@@ -7,18 +7,23 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /**
  * Reads `min-release-age` (in days) from the `.npmrc` from the repo root.
  */
-let cachedMinReleaseAgeDays: number = 4; // default to 4 days
+let cachedMinReleaseAgeDays: number | undefined = undefined;
 export function getMinReleaseAgeDays(): number {
   if (cachedMinReleaseAgeDays !== undefined) return cachedMinReleaseAgeDays;
 
   // scheduler is always launched from repo root
   const contents = readFileSync(join(process.cwd(), '.npmrc'), 'utf8');
   const match = contents.match(/^\s*min-release-age\s*=\s*(\d+(?:\.\d+)?)/m);
-  if (match) {
-    const value = Number(match[1]);
-    if (Number.isFinite(value) && value > 0) {
-      cachedMinReleaseAgeDays = value;
-    }
+  const value = match ? Number(match[1]) : NaN;
+  if (value > 0) {
+    cachedMinReleaseAgeDays = value;
+  } else {
+    console.error(
+      match
+        ? `Invalid value for min-release-age (${value}), defaulting to 4 days`
+        : `Property min-release-age not found, defaulting to 4 days`
+    );
+    cachedMinReleaseAgeDays = 4;
   }
   return cachedMinReleaseAgeDays;
 }

--- a/packages/scheduler/src/npm.ts
+++ b/packages/scheduler/src/npm.ts
@@ -1,4 +1,44 @@
 import semver from 'semver';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Reads `min-release-age` (in days) from the `.npmrc` from the repo root.
+ */
+let cachedMinReleaseAgeDays: number = 4; // default to 4 days
+export function getMinReleaseAgeDays(): number {
+  if (cachedMinReleaseAgeDays !== undefined) return cachedMinReleaseAgeDays;
+
+  // scheduler is always launched from repo root
+  const contents = readFileSync(join(process.cwd(), '.npmrc'), 'utf8');
+  const match = contents.match(/^\s*min-release-age\s*=\s*(\d+(?:\.\d+)?)/m);
+  if (match) {
+    const value = Number(match[1]);
+    if (Number.isFinite(value) && value > 0) {
+      cachedMinReleaseAgeDays = value;
+    }
+  }
+  return cachedMinReleaseAgeDays;
+}
+
+/*
+ * Returns true if the package version is older than the minimum release age.
+ * This is used to filter out new package versions to avoid issues with bugs, supply chain attacks, etc.
+ */
+function isOlderThanMinAge(publishDate: Date, {packageName, version}: {packageName: string, version: string}) {
+  const minReleaseAgeDays = getMinReleaseAgeDays();
+  const maxPublishDate = new Date(Date.now() - minReleaseAgeDays * MS_PER_DAY);
+
+  if (publishDate > maxPublishDate) {
+    console.log(
+      `   ⏳ Skipping ${packageName}@${version} - published less than ${minReleaseAgeDays} day(s) ago (min-release-age)`
+    );
+    return false;
+  }
+  return true;
+}
 
 export interface NpmVersionInfo {
   version: string;
@@ -193,6 +233,7 @@ export async function findMatchingVersionsFromNPM(
   return allVersions
     .filter((v) => !semver.prerelease(v.version))
     .filter((v) => matchesVersionPattern(v.version, versionMatcher))
+    .filter((v) => isOlderThanMinAge(v.publishDate, {packageName, version: v.version}))
     .filter((v) => {
       if (minPublishDate) {
         const publishDate = new Date(v.publishDate);

--- a/packages/scheduler/src/npm.ts
+++ b/packages/scheduler/src/npm.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## 📝 Description

avoid failures like:
```
ShellError: Failed with exit code 1
 exitCode: 1,
   stdout: "",
   stderr: "npm error code ETARGET\nnpm error notarget No matching version found for react-native-worklets@0.10.2 with a date before 7/5/2026, 12:20:15 PM.\nnpm error notarget In most cases you or one of your dependencies are requesting a package version that doesn't exist.\nnpm error A complete log of this run can be found in: /Users/runner/.npm/_logs/2026-07-09T12_20_15_394Z-debug-0.log\n",
```
> rnworklets were released 12h ago, so 4days-min-age failed

source: https://github.com/software-mansion/rnrepo/actions/runs/29012220481/job/86098364112
