### PR TITLE
fix(builder): match ABI as exact path segment in codegen extraction

### DIFF
--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -80,7 +80,7 @@ def createExtractCodegenBinariesTask(libraryProject, codegenName, buildType) {
                 // otherwise arch "x86" would also match the "x86_64" directory and 
                 // the 32-bit artifact would be in the 64-bit dir. See issue #419.
                 def staticLib = fileTree(dir: appCxxDir, include: "**/$moduleFolder/**/libreact_codegen_${codegenName}.a")
-                    .find { arch in it.path.split(File.separator) }
+                    .find { arch in it.path.split(java.util.regex.Pattern.quote(File.separator)) }
                 if (staticLib) {
                     def assetBuildType = buildType == "Release" ? "relwithdebinfo" : buildType.toLowerCase()
                     def destDir = file("${libraryProject.projectDir}/src/main/assets/${assetBuildType}/$arch")

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -75,9 +75,12 @@ def createExtractCodegenBinariesTask(libraryProject, codegenName, buildType) {
             def archs = ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
             def moduleFolder = "${codegenName}_autolinked_build"
             archs.each { arch ->
-                // Find any .a file for this arch (will be whatever was just built)
+                // Find the .a file for this arch. Match the ABI as a full path
+                // segment (split on File.separator) rather than a bare substring,
+                // otherwise arch "x86" would also match the "x86_64" directory and 
+                // the 32-bit artifact would be in the 64-bit dir. See issue #419.
                 def staticLib = fileTree(dir: appCxxDir, include: "**/$moduleFolder/**/libreact_codegen_${codegenName}.a")
-                    .find { it.path.contains(arch) }
+                    .find { arch in it.path.split(File.separator) }
                 if (staticLib) {
                     def assetBuildType = buildType == "Release" ? "relwithdebinfo" : buildType.toLowerCase()
                     def destDir = file("${libraryProject.projectDir}/src/main/assets/${assetBuildType}/$arch")


### PR DESCRIPTION
## 📝 Description

The codegen static-library extraction in add-publishing.gradle located each ABI's libreact_codegen_<name>.a with `it.path.contains(arch)`. Because "x86" is a substring of "x86_64", the lookup for the x86 ABI also matched the x86_64 build directory, and fileTree traversal order could return the 64-bit path first. The 32-bit x86 asset directory was then populated with 64-bit object code, so linking the x86 ABI failed at consume time (ld.lld -m elf_i386 rejects the 64-bit objects).

Match the ABI as a full path segment (split on File.separator) instead of a bare substring, so "x86" can no longer collide with "x86_64". The other three ABIs have unique names and were unaffected; this only changed the x86 result.

This is a latent defect in the x86 output of every codegen library built with the affected build-tools, surfacing intermittently depending on the target ABI set and filesystem traversal order. Existing x86 codegen artifacts (e.g. react-native-screens) will be rebuilt and republished.

Fixes #419

## 🧪 Testing

build
```
bun run build-library-android.ts react-native-screens 4.26.2 0.85.3 /tmp/TEMP_SCREENS_4262_0853_archpaths
```
download
```
https://packages.rnrepo.org/releases/org/rnrepo/public/react-native-screens/4.26.2/react-native-screens-4.26.2-rn0.85.3-codegen.aar
```
compare extracted files
```
$ diff react-native-screens-4.26.2-rn0.85.3-codegen-FIXED-kopia.aar/assets/debug/x86/libreact_codegen_rnscreens.a react-native-screens-4.26.2-rn0.85.3-codegen-FIXED-kopia.aar/assets/debug/x86_64/libreact_codegen_rnscreens.a

Binary files 
react-native-screens-4.26.2-rn0.85.3-codegen-FIXED-kopia.aar/assets/debug/x86/libreact_codegen_rnscreens.a and 
react-native-screens-4.26.2-rn0.85.3-codegen-FIXED-kopia.aar/assets/debug/x86_64/libreact_codegen_rnscreens.a 
differ

---

$ diff react-native-screens-4.26.2-rn0.85.3-codegen-kopia.aar/assets/debug/x86/libreact_codegen_rnscreens.a react-native-screens-4.26.2-rn0.85.3-codegen-kopia.aar/assets/debug/x86_64/libreact_codegen_rnscreens.a
# exit 0 means files are the same
```