### PR TITLE
bump versions 0.2.2 and 0.3.6

### DIFF
--- a/.github/actions/setup-expo-example-app/action.yml
+++ b/.github/actions/setup-expo-example-app/action.yml
@@ -8,7 +8,7 @@ inputs:
   expo_sdk_major_version:
     description: 'Expo SDK major version used in `create-expo-app@latest --template default@sdk-<major_version>`'
     required: false
-    default: '56'
+    default: '57'
   disable_rnrepo:
     description: 'Disable rnrepo config plugin'
     required: false

--- a/.github/actions/setup-rn-example-app/action.yml
+++ b/.github/actions/setup-rn-example-app/action.yml
@@ -8,7 +8,7 @@ inputs:
   rn_version:
     description: 'React Native version used in `@react-native-community/cli@latest init --version <rn_version>`'
     required: false
-    default: '0.85.0'
+    default: '0.86.0'
   disable_rnrepo:
     description: 'Disable rnrepo plugin'
     required: false

--- a/.github/workflows/build-example-expo-app.yml
+++ b/.github/workflows/build-example-expo-app.yml
@@ -16,7 +16,7 @@ on:
         description: 'Expo SDK major version used in `create-expo-app@latest --template default@sdk-<major_version>`'
         required: false
         type: string
-        default: '56'
+        default: '57'
       request_android:
         description: 'Request android build'
         required: false
@@ -38,7 +38,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  EXPO_SDK_MAJOR_VERSION: ${{ github.event.inputs.expo_sdk_major_version || '56' }}
+  EXPO_SDK_MAJOR_VERSION: ${{ github.event.inputs.expo_sdk_major_version || '57' }}
   EXAMPLE_APP: expoExampleApp
 
 jobs:

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -16,7 +16,7 @@ on:
         description: 'React Native version used in `@react-native-community/cli@latest init --version <rn_version>`'
         required: false
         type: string
-        default: '0.85.0'
+        default: '0.86.0'
       request_android:
         description: 'Request android build'
         required: false
@@ -43,7 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RN_VERSION: ${{ github.event.inputs.rn_version || '0.85.0' }}
+  RN_VERSION: ${{ github.event.inputs.rn_version || '0.86.0' }}
   EXAMPLE_APP: rnExampleApp
   LIBRARIES: ${{ github.event.inputs.libraries || 'react-native-worklets@0.8.1 react-native-reanimated@4.3.0 react-native-gesture-handler@2.31.2 react-native-screens@4.25.0' }}
 

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.2] - 2026-07-24
 
 ### Changed
 - Gradle plugin resolves artifacts with latest revision of version instead of exact version (#421)

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - 2026-07-24
+## [0.2.2] - 2026-07-27
 
 ### Changed
 - Gradle plugin resolves artifacts with latest revision of version instead of exact version (#421)

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/build-tools",
   "title": "RNRepo Prebuilds plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "RNRepo plugin for handling prebuilt binaries of iOS and Android libraries",
   "scripts": {
     "build": "./gradle-plugin/gradlew build --no-daemon -p gradle-plugin",

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-07-24
+
+### Changed
+- Bumped @rnrepo/build-tools dependency to 0.2.2 (#422)
+
 ## [0.3.5] - 2026-07-16
 
 ### Changed

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.6] - 2026-07-24
+## [0.3.6] - 2026-07-27
 
 ### Changed
 - Bumped @rnrepo/build-tools dependency to 0.2.2 (#422)

--- a/packages/expo-config-plugin/package.json
+++ b/packages/expo-config-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnrepo/expo-config-plugin",
   "title": "RNRepo expo config plugin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Plugin for configuring RNRepo prebuilt packages in Expo projects",
   "sideEffects": false,
   "main": "build/withRNRepoPlugin.js",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/config-plugins": "*",
     "@expo/config-types": "*",
-    "@rnrepo/build-tools": "0.2.1"
+    "@rnrepo/build-tools": "0.2.2"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"


### PR DESCRIPTION
## 📝 Description

"name": "@rnrepo/expo-config-plugin",
"version": "0.3.6",

"name": "@rnrepo/build-tools",
"version": "0.2.2",

also bumped RN (to 0.86) and expo (to sdk@57) in CI