### PR TITLE
Route org.rnrepo.public artifacts exclusively to RNRepo maven

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Gradle plugin resolves artifacts with latest revision of version instead of exact version (#421)
 
+### Fixed
+- Route `org.rnrepo.public` artifacts exclusively to the RNRepo Maven repository so a Maven Central timeout no longer fails the build (#424)
+
 ## [0.2.1] - 2026-07-16
 
 ### Fixed

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -274,9 +274,7 @@ class PrebuildsPlugin : Plugin<Project> {
                 // RNRepo and prevents any other repository from being queried for it, regardless of order.
                 currentProject.repositories.exclusiveContent { exclusiveContent ->
                     exclusiveContent.forRepository {
-                        currentProject.repositories.maven { repo ->
-                            repo.url = rnrepoUrl
-                        }
+                        maven { url = rnrepoUrl }
                     }
                     exclusiveContent.filter { descriptor ->
                         descriptor.includeGroup(RNREPO_GROUP)

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -274,7 +274,9 @@ class PrebuildsPlugin : Plugin<Project> {
                 // RNRepo and prevents any other repository from being queried for it, regardless of order.
                 currentProject.repositories.exclusiveContent { exclusiveContent ->
                     exclusiveContent.forRepository {
-                        maven { url = rnrepoUrl }
+                        currentProject.repositories.maven { repo ->
+                            repo.url = rnrepoUrl
+                        }
                     }
                     exclusiveContent.filter { descriptor ->
                         descriptor.includeGroup(RNREPO_GROUP)

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -69,6 +69,9 @@ class PrebuildsPlugin : Plugin<Project> {
     // config for denyList
     private val CONFIG_FILE_NAME = "rnrepo.config.json"
 
+    // Maven group id under which all RNRepo prebuilt artifacts are published
+    private val RNREPO_GROUP = "org.rnrepo.public"
+
     // known packages with unstable cpp code
     // use grade package name format
     // .* as wildcard for any suffix
@@ -264,8 +267,20 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info("RNRepo maven repository already present for project ${currentProject.path}, skipping adding url.")
                     return@forEach
                 }
-                currentProject.repositories.maven { repo ->
-                    repo.url = rnrepoUrl
+                // Declare the RNRepo group as served exclusively by the RNRepo repository. Without this,
+                // the repository is appended after google()/mavenCentral() and Gradle queries Maven Central
+                // for org.rnrepo.public:* first — a Maven Central read timeout then fails the whole build
+                // before RNRepo is ever tried. Exclusive content routes org.rnrepo.public directly to
+                // RNRepo and prevents any other repository from being queried for it, regardless of order.
+                currentProject.repositories.exclusiveContent { exclusiveContent ->
+                    exclusiveContent.forRepository {
+                        currentProject.repositories.maven { repo ->
+                            repo.url = rnrepoUrl
+                        }
+                    }
+                    exclusiveContent.filter { descriptor ->
+                        descriptor.includeGroup(RNREPO_GROUP)
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Inject the RNRepo Maven repository as exclusive content for `org.rnrepo.public` so a Maven Central timeout no longer fails the build (#424)
+
 ## [0.3.5] - 2026-07-16
 
 ### Changed

--- a/packages/expo-config-plugin/__tests__/withRNRepoPlugin.test.ts
+++ b/packages/expo-config-plugin/__tests__/withRNRepoPlugin.test.ts
@@ -93,6 +93,8 @@ describe('withRNRepoPlugin', () => {
 
       expect(mockConfig.modResults.contents).toContain('allprojects {');
       expect(mockConfig.modResults.contents).toContain('maven { url "https://packages.rnrepo.org/releases" }');
+      expect(mockConfig.modResults.contents).toContain('exclusiveContent {');
+      expect(mockConfig.modResults.contents).toContain('includeGroup "org.rnrepo.public"');
     });
 
     it('should not duplicate maven repository', () => {
@@ -106,10 +108,17 @@ describe('withRNRepoPlugin', () => {
         
         allprojects {
             repositories {
-                maven { url "https://packages.rnrepo.org/releases" }
+                exclusiveContent {
+                    forRepository {
+                        maven { url "https://packages.rnrepo.org/releases" }
+                    }
+                    filter {
+                        includeGroup "org.rnrepo.public"
+                    }
+                }
             }
         }
-        
+
         apply plugin: "com.facebook.react.rootproject"
       `;
 

--- a/packages/expo-config-plugin/src/withRNRepoPlugin.ts
+++ b/packages/expo-config-plugin/src/withRNRepoPlugin.ts
@@ -20,7 +20,14 @@ const applyPluginFacebookRootProject =
 const mavenAllProjectsBlock = `
 allprojects {
     repositories {
-        maven { url "https://packages.rnrepo.org/releases" }
+        exclusiveContent {
+            forRepository {
+                maven { url "https://packages.rnrepo.org/releases" }
+            }
+            filter {
+                includeGroup "org.rnrepo.public"
+            }
+        }
     }
 }`;
 // iOS


### PR DESCRIPTION
## 📝 Description

The RNRepo Maven repository was added to each project's repositories without a content filter (the Gradle plugin appends it, and @rnrepo/expo-config-plugin injects a plain `maven { url ... }` into allprojects). Because google() and mavenCentral() are declared earlier, Gradle queried Maven Central for org.rnrepo.public:* artifacts first. A Maven Central read timeout then failed the whole build before the RNRepo repository was ever tried.

Declare org.rnrepo.public as exclusive content of the RNRepo repository via `exclusiveContent { forRepository { ... }; filter { includeGroup(...) } }` in both the Gradle plugin (PrebuildsPlugin.addRNRepoRepository) and the injected allprojects block from the Expo config plugin. Gradle now routes org.rnrepo.public requests directly to RNRepo and never queries any other repository for that group, regardless of order.

This is stronger than prepending the repository (order-independent) and than a plain `content { includeGroup ... }` filter, which restricts only what RNRepo serves and would still let Maven Central be queried for the group.

Fixes #423

## Test

before: rnsac was searched everywhere
```
2026-07-24T15:19:19.669+0200 [DEBUG] [org.gradle.internal.operations.DefaultBuildOperationRunner] Build operation 'Download https://packages.rnrepo.org/private/org/rnrepo/public/react-native-safe-area-context/maven-metadata.xml' started
2026-07-24T15:19:19.810+0200 [DEBUG] [org.gradle.internal.operations.DefaultBuildOperationRunner] Build operation 'Download https://central.sonatype.com/repository/maven-snapshots/org/rnrepo/public/react-native-safe-area-context/maven-metadata.xml' started
2026-07-24T15:19:20.419+0200 [DEBUG] [org.gradle.internal.operations.DefaultBuildOperationRunner] Build operation 'Download https://repo.maven.apache.org/maven2/org/rnrepo/public/react-native-safe-area-context/maven-metadata.xml' started
```

after: rnsac was searched only in RNRepoMaven
```
2026-07-24T15:20:27.972+0200 [DEBUG] [org.gradle.internal.operations.DefaultBuildOperationRunner] Build operation 'Download https://packages.rnrepo.org/private/org/rnrepo/public/react-native-safe-area-context/maven-metadata.xml' started
```
