### PR TITLE
update libs versions for ci

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -5,7 +5,7 @@ inputs:
   xcode-version:
     description: 'Xcode version to use'
     required: false
-    default: '26.3'
+    default: '26.6'
   cocoapods-version:
     description: 'CocoaPods version to install'
     required: false

--- a/.github/workflows/build-example-rn-app.yml
+++ b/.github/workflows/build-example-rn-app.yml
@@ -45,7 +45,7 @@ concurrency:
 env:
   RN_VERSION: ${{ github.event.inputs.rn_version || '0.86.0' }}
   EXAMPLE_APP: rnExampleApp
-  LIBRARIES: ${{ github.event.inputs.libraries || 'react-native-worklets@0.8.1 react-native-reanimated@4.3.0 react-native-gesture-handler@2.31.2 react-native-screens@4.25.0' }}
+  LIBRARIES: ${{ github.event.inputs.libraries || 'react-native-worklets@0.11.3 react-native-reanimated@4.5.3 react-native-gesture-handler@3.1.0 react-native-screens@4.26.2' }}
 
 jobs:
   check-changes:

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/build-tools": {
       "name": "@rnrepo/build-tools",
-      "version": "0.2.1",
+      "version": "0.2.2",
     },
     "packages/builder": {
       "name": "@rnrepo/builder",
@@ -64,11 +64,11 @@
     },
     "packages/expo-config-plugin": {
       "name": "@rnrepo/expo-config-plugin",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@expo/config-plugins": "*",
         "@expo/config-types": "*",
-        "@rnrepo/build-tools": "0.2.1",
+        "@rnrepo/build-tools": "0.2.2",
       },
       "devDependencies": {
         "expo-module-scripts": "^5.0.7",

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - 2026-07-30
+## [0.2.2] - 2026-08-03
 
 ### Changed
 - Gradle plugin resolves artifacts with latest revision of version instead of exact version (#421)

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - 2026-07-27
+## [0.2.2] - 2026-07-30
 
 ### Changed
 - Gradle plugin resolves artifacts with latest revision of version instead of exact version (#421)

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.6] - 2026-07-30
+## [0.3.6] - 2026-08-03
 
 ### Changed
 - Bumped @rnrepo/build-tools dependency to 0.2.2 (#422)

--- a/packages/expo-config-plugin/CHANGELOG.md
+++ b/packages/expo-config-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.6] - 2026-07-27
+## [0.3.6] - 2026-07-30
 
 ### Changed
 - Bumped @rnrepo/build-tools dependency to 0.2.2 (#422)


### PR DESCRIPTION
## 📝 Description

old libs were not compatible with current bumped rn@0.86

## 🧪 Testing

- CIs on this pr passes (both expo & pure rn)