### PR TITLE
Keep library header overrides on the prebuilt codegen include path

### DIFF
--- a/packages/builder/build-library-android.ts
+++ b/packages/builder/build-library-android.ts
@@ -215,11 +215,43 @@ async function buildCodegenAar(
 }
 
 /**
- * Patches CMakeLists.txt in libraries with custom codegen to use STATIC instead of SHARED.
- * Many libraries like react-native-screens build their codegen as shared library,
- * but we need static libraries to create AAR artifacts.
+ * Every `add_library(<target> SHARED ...)` becomes STATIC: shared libraries leave
+ * a .so that we do not bundle, and libraries like react-native-screens declare
+ * their codegen that way.
+ *
+ * OBJECT libraries have the same problem for our purposes - they leave no
+ * linkable archive on disk at all - but OBJECT is also a legitimate way to build
+ * an internal target that is later assembled into another one, so only the
+ * `react_codegen_*` targets (e.g. the hand-written CMakeLists of
+ * react-native-reanimated) are switched over.
  */
-async function patchCMakeListsToStatic(packagePath: string): Promise<void> {
+const CMAKE_STATIC_PATCHES = [
+  {
+    label: 'SHARED → STATIC',
+    // Any target: we never ship .so files in the AAR
+    regex: /add_library\s*\(\s*([^\s)]+)\s+SHARED/g,
+  },
+  {
+    label: 'OBJECT → STATIC',
+    // Codegen targets only, other OBJECT targets may be intentional
+    regex: /add_library\s*\(\s*(react_codegen_[A-Za-z0-9_]+)\s+OBJECT\b/g,
+  },
+];
+
+/**
+ * Patches CMakeLists.txt in libraries with custom codegen so that codegen ends
+ * up in a linkable static archive (.a) that can be bundled into the AAR.
+ *
+ * Without it `extractCodegenBinaries*` (add-publishing.gradle) finds no archive,
+ * only prints a warning, and publishes an AAR with the codegen silently missing.
+ * That is exactly why a failure here is fatal for a library that publishes a
+ * codegen AAR (`hasCodegenConfig`) - the build would otherwise succeed and ship
+ * an artifact whose codegen is missing.
+ */
+async function patchCMakeListsToStatic(
+  packagePath: string,
+  hasCodegenConfig: boolean
+): Promise<void> {
   const configPath = join(packagePath, 'react-native.config.js');
   
   if (!existsSync(configPath)) {
@@ -254,30 +286,38 @@ async function patchCMakeListsToStatic(packagePath: string): Promise<void> {
     console.log(`   CMakeLists.txt found at ${absoluteCMakePath}`);
 
     // Read CMakeLists.txt
-    let cmakeContent = readFileSync(absoluteCMakePath, 'utf-8');
-    
-    // Check if it contains add_library with SHARED
-    if (!cmakeContent.includes('add_library') || !cmakeContent.includes('SHARED')) {
-      console.log('   CMakeLists.txt does not contain add_library with SHARED');
+    const originalContent = readFileSync(absoluteCMakePath, 'utf-8');
+    if (!originalContent.includes('add_library')) {
+      console.log('   CMakeLists.txt does not contain add_library');
       return;
     }
 
-    // Replace SHARED with STATIC in add_library calls
-    const originalContent = cmakeContent;
-    cmakeContent = cmakeContent.replace(
-      /add_library\s*\(\s*([^\s)]+)\s+SHARED/g,
-      'add_library(\n  $1\n  STATIC'
-    );
+    // Replace non-static library types with STATIC in add_library calls
+    let cmakeContent = originalContent;
+    const appliedPatches: string[] = [];
+    for (const { label, regex } of CMAKE_STATIC_PATCHES) {
+      const patched = cmakeContent.replace(regex, 'add_library(\n  $1\n  STATIC');
+      if (patched !== cmakeContent) {
+        appliedPatches.push(label);
+        cmakeContent = patched;
+      }
+    }
 
-    if (cmakeContent !== originalContent) {
+    if (appliedPatches.length > 0) {
       writeFileSync(absoluteCMakePath, cmakeContent, 'utf-8');
-      console.log(`   ✓ Patched ${absoluteCMakePath}: SHARED → STATIC`);
+      console.log(`   ✓ Patched ${absoluteCMakePath}: ${appliedPatches.join(', ')}`);
     } else {
-      console.log('   No SHARED libraries found to patch');
+      console.log('   No libraries found to patch');
     }
   } catch (error) {
+    if (hasCodegenConfig) {
+      throw new Error(
+        `Failed to patch CMakeLists.txt of ${libraryName}, its codegen would be missing from the published AAR: ${error}`
+      );
+    }
+    // No codegen AAR is published for this library, so a failed patch cannot
+    // silently strip anything from the artifact - continue with the build
     console.error(`   ⚠️ Failed to patch CMakeLists.txt:`, error);
-    // Don't throw - continue with build even if patching fails
   }
 }
 
@@ -325,10 +365,10 @@ async function buildAAR(appDir: string, license: AllowedLicense[]) {
   // Check if library has custom react-native.config.js file, which may override codegen settings
   const hasCustomCodegen = existsSync(join(packagePath, 'react-native.config.js'));
   
-  // If library has custom codegen, we need to patch CMakeLists.txt to use STATIC instead of SHARED
+  // If library has custom codegen, we need to patch CMakeLists.txt to build a linkable static archive
   if (hasCustomCodegen) {
     console.log('⚠️ Library has custom codegen configuration in react-native.config.js');
-    await patchCMakeListsToStatic(packagePath);
+    await patchCMakeListsToStatic(packagePath, hasCodegenConfig);
   }
 
   const mavenLocalLibraryLocationPath = join(

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -23,13 +23,44 @@ allprojects { project ->
     }
 }
 
-def generateCMakeContent(codegenName) {
+// Some libraries ship hand-written headers that deliberately shadow their codegen output. The
+// clearest case is react-native-gesture-handler: shared/shadowNodes holds its own copy of
+// react/renderer/components/rngesturehandler_codegen/ComponentDescriptors.h and only that copy
+// declares RNGestureHandlerDetectorComponentDescriptor. The library's own CMakeLists puts that
+// directory on the include path *before* the codegen one, so the override wins.
+//
+// packageCppHeaders flattens every header source into assets/headers, which loses the knowledge of
+// which subdirectories were include roots. Recover it here: any directory below assets/headers that
+// carries its own react/renderer/components/<codegenName> subtree is such an override root and has
+// to be searched before assets/headers itself, otherwise the plain codegen header wins and the
+// consuming app fails to compile.
+def findCodegenOverrideIncludeRoots(headersDir, codegenName) {
+    if (codegenName == null || !headersDir.isDirectory()) {
+        return []
+    }
+    def roots = []
+    // eachDirRecurse skips headersDir itself, which is what we want — the codegen tree lives
+    // directly under it and is emitted separately.
+    headersDir.eachDirRecurse { dir ->
+        if (new File(dir, "react/renderer/components/${codegenName}").isDirectory()) {
+            roots << headersDir.toPath().relativize(dir.toPath()).toString().replace('\\', '/')
+        }
+    }
+    return roots.sort()
+}
+
+def generateCMakeContent(codegenName, overrideIncludeRoots) {
     // Uses CMAKE_CURRENT_LIST_DIR-relative paths so the file works wherever it is extracted.
     // Groovy \$ produces a literal $ in the output (cmake variable reference).
     //
     // STATIC IMPORTED targets cannot be used with non-INTERFACE keyword in target_link_libraries,
     // which RN's ReactNative-application.cmake does internally. A real STATIC target (with a
     // generated placeholder source) works correctly in all CMake linking contexts.
+    def includeDirs = overrideIncludeRoots.collect { "\${CMAKE_CURRENT_LIST_DIR}/../headers/${it}" }
+    includeDirs << "\${CMAKE_CURRENT_LIST_DIR}/../headers"
+    includeDirs << "\${CMAKE_CURRENT_LIST_DIR}/../headers/react/renderer/components/${codegenName}"
+    def includeDirsBlock = includeDirs.collect { "    \"${it}\"" }.join("\n")
+
     return """cmake_minimum_required(VERSION 3.13)
 
 if(CMAKE_BUILD_TYPE)
@@ -50,8 +81,7 @@ endif()
 add_library(react_codegen_${codegenName} STATIC "\${_rnrepo_src_${codegenName}}")
 
 target_include_directories(react_codegen_${codegenName} PUBLIC
-    "\${CMAKE_CURRENT_LIST_DIR}/../headers"
-    "\${CMAKE_CURRENT_LIST_DIR}/../headers/react/renderer/components/${codegenName}"
+${includeDirsBlock}
 )
 
 target_link_libraries(react_codegen_${codegenName}
@@ -168,10 +198,18 @@ def configureCodegenTasks(project) {
 
     def packageCodegenCMakeTask = project.tasks.register("packageCodegenCMake") {
         onlyIf { codegenName != null }
+        // The include roots are derived from the packaged headers, so they have to exist first.
+        dependsOn(packageHeadersTask)
         doLast {
+            def headersDestDir = file("${project.projectDir}/src/main/assets/headers")
+            def overrideIncludeRoots = findCodegenOverrideIncludeRoots(headersDestDir, codegenName)
+            if (overrideIncludeRoots) {
+                println "📦 Codegen header overrides for ${codegenName}: ${overrideIncludeRoots.join(', ')}"
+            }
+
             def cmakeDir = file("${project.projectDir}/src/main/assets/cmake")
             cmakeDir.mkdirs()
-            file("${cmakeDir}/CMakeLists.txt").text = generateCMakeContent(codegenName)
+            file("${cmakeDir}/CMakeLists.txt").text = generateCMakeContent(codegenName, overrideIncludeRoots)
             println "📦 Packaged codegen CMakeLists.txt to assets/cmake"
         }
     }

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -75,6 +75,65 @@ def findCodegenOverrideIncludeRoots(headersDir, codegenName) {
     return roots.toList().sort()
 }
 
+// The counterpart to findCodegenOverrideIncludeRoots, run against the package sources instead of
+// the already-copied headers. A library can keep its shadowing headers outside every directory
+// packageCppHeaders knows about — reanimated puts them in Common/NativeView, next to the Common/cpp
+// that is collected — and those never reach the AAR at all, so the consumer cannot compile the
+// descriptor the codegen archive already contains.
+//
+// Rather than cataloguing such directories by hand, detect them by shape: any directory in the
+// package that holds its own react/renderer/components/<codegenName> headers is an override root,
+// for the same reason the post-copy scan treats one as such.
+//
+// Returns package-relative paths. Copying each into assets/headers/<that same relative path> keeps
+// the destination unique without inventing names, and leaves a prefix for the post-copy scan to
+// rediscover and rank ahead of assets/headers.
+def findPackageCodegenOverrideRoots(packageDir, codegenName, collectedDirs) {
+    if (codegenName == null || !packageDir.isDirectory()) {
+        return []
+    }
+    def packagePath = packageDir.toPath().toAbsolutePath().normalize()
+    def marker = "react/renderer/components/${codegenName}/"
+    // Directories whose headers are already in assets/headers by the time this runs: the sources
+    // packageCppHeaders flattens in, plus assets/headers itself, which lives inside the package and
+    // would otherwise be rediscovered as a root and copied into itself. A root inside any of them is
+    // handled by the post-copy scan, and copying it twice would only duplicate headers in the AAR.
+    def covered = collectedDirs.findAll { it.exists() }
+        .collect { it.toPath().toAbsolutePath().normalize() }
+    def roots = [] as Set
+
+    def stream = java.nio.file.Files.walk(packagePath)
+    try {
+        stream.forEach { path ->
+            if (!java.nio.file.Files.isRegularFile(path) || !path.toString().endsWith('.h')) {
+                return
+            }
+            // Generated codegen output lives under android/build and is the base these roots
+            // shadow, so it must never be mistaken for one of them.
+            def relative = packagePath.relativize(path).toString().replace('\\', '/')
+            def segments = relative.split('/') as List
+            if (segments.any { it in ['build', 'node_modules', '.cxx', '.gradle'] }) {
+                return
+            }
+            def markerIndex = relative.indexOf(marker)
+            // markerIndex == 0 would make the package root itself an include root, which would copy
+            // the entire package; only a proper subdirectory qualifies.
+            if (markerIndex <= 0) {
+                return
+            }
+            def root = relative.substring(0, markerIndex - 1)
+            if (covered.any { packagePath.resolve(root).startsWith(it) }) {
+                return
+            }
+            roots << root
+        }
+    } finally {
+        stream.close()
+    }
+
+    return roots.toList().sort()
+}
+
 def generateCMakeContent(codegenName, overrideIncludeRoots) {
     // Uses CMAKE_CURRENT_LIST_DIR-relative paths so the file works wherever it is extracted.
     // Groovy \$ produces a literal $ in the output (cmake variable reference).
@@ -215,6 +274,24 @@ def configureCodegenTasks(project) {
                         include "**/*.h"
                         // Preserve folder structure relative to 'source'
                     }
+                }
+            }
+
+            // Roots that shadow codegen output and sit outside every directory above. They keep
+            // their package-relative subdirectory rather than being flattened in with the rest:
+            // packageCodegenCMake keys off exactly that prefix to rank them ahead of
+            // assets/headers, mirroring the include order the library's own CMakeLists uses.
+            // Flattening them would clobber the generated headers instead of shadowing them.
+            def packageDir = file("${project.projectDir}/..")
+            def headerOverrideRoots = findPackageCodegenOverrideRoots(
+                packageDir, codegenName, headerSources + [headersDestDir])
+
+            headerOverrideRoots.each { root ->
+                println "🔍 Collecting override headers from: ${root}"
+                project.copy {
+                    from new File(packageDir, root)
+                    into new File(headersDestDir, root)
+                    include "**/*.h"
                 }
             }
 

--- a/packages/builder/gradle_init_scripts/add-publishing.gradle
+++ b/packages/builder/gradle_init_scripts/add-publishing.gradle
@@ -30,23 +30,49 @@ allprojects { project ->
 // directory on the include path *before* the codegen one, so the override wins.
 //
 // packageCppHeaders flattens every header source into assets/headers, which loses the knowledge of
-// which subdirectories were include roots. Recover it here: any directory below assets/headers that
-// carries its own react/renderer/components/<codegenName> subtree is such an override root and has
-// to be searched before assets/headers itself, otherwise the plain codegen header wins and the
-// consuming app fails to compile.
+// which subdirectories were include roots. Recover it here: a subdirectory holding its own
+// react/renderer/components/<codegenName> headers is such an override root and has to be searched
+// before assets/headers itself, otherwise the plain codegen header wins and the consuming app fails
+// to compile.
+//
+// Two limitations, both deliberate:
+//   - Override roots are always emitted first. We do not parse the library's own CMakeLists, so a
+//     library that intentionally ranks an extra root *below* codegen would resolve differently here
+//     than in a source build. No catalogued library does that today.
+//   - Only roots carrying a codegen-namespaced subtree are recovered. An include root of any other
+//     shape (say cpp/include holding <Foo.h>) stays unreachable after flattening.
 def findCodegenOverrideIncludeRoots(headersDir, codegenName) {
     if (codegenName == null || !headersDir.isDirectory()) {
         return []
     }
-    def roots = []
-    // eachDirRecurse skips headersDir itself, which is what we want — the codegen tree lives
-    // directly under it and is emitted separately.
-    headersDir.eachDirRecurse { dir ->
-        if (new File(dir, "react/renderer/components/${codegenName}").isDirectory()) {
-            roots << headersDir.toPath().relativize(dir.toPath()).toString().replace('\\', '/')
+    def headersPath = headersDir.toPath()
+    def marker = "react/renderer/components/${codegenName}/"
+    def roots = [] as Set
+
+    // Keyed off actual header files rather than directory existence: Gradle's copy recreates the
+    // whole directory structure even when the "**/*.h" filter matches nothing, so a subtree built
+    // solely from .cpp files would otherwise be reported as a root. Files.walk does not follow
+    // symlinks, so a link back to an ancestor cannot recurse forever.
+    def stream = java.nio.file.Files.walk(headersPath)
+    try {
+        stream.forEach { path ->
+            if (!java.nio.file.Files.isRegularFile(path) || !path.toString().endsWith('.h')) {
+                return
+            }
+            def relative = headersPath.relativize(path).toString().replace('\\', '/')
+            def markerIndex = relative.indexOf(marker)
+            // markerIndex == 0 means the header merged straight into assets/headers, which is
+            // already an include root — only a non-empty prefix forms a separate one.
+            if (markerIndex > 0) {
+                roots << relative.substring(0, markerIndex - 1)
+            }
         }
+    } finally {
+        stream.close()
     }
-    return roots.sort()
+
+    // Sorted so the generated CMakeLists is byte-stable across builds.
+    return roots.toList().sort()
 }
 
 def generateCMakeContent(codegenName, overrideIncludeRoots) {
@@ -147,6 +173,9 @@ def configureCodegenTasks(project) {
     def extractDebugTask = createExtractCodegenBinariesTask(project, codegenName, "Debug")
     def extractReleaseTask = createExtractCodegenBinariesTask(project, codegenName, "Release")
 
+    // Written by packageCppHeaders, read back by packageCodegenCMake — keep the two in sync here.
+    def headersDestDir = project.file("${project.projectDir}/src/main/assets/headers")
+
     // Task to package headers - must run after codegen generation
     def packageHeadersTask = project.tasks.register("packageCppHeaders") {
         onlyIf { codegenName != null }
@@ -158,7 +187,9 @@ def configureCodegenTasks(project) {
         }
         
         doLast {
-            def headersDestDir = file("${project.projectDir}/src/main/assets/headers")
+            // Wipe first: nothing else writes here, and leftovers from an earlier run would be both
+            // packaged into the AAR and picked up as include roots by packageCodegenCMake.
+            headersDestDir.deleteDir()
             headersDestDir.mkdirs()
 
             def headerSources = [
@@ -201,7 +232,6 @@ def configureCodegenTasks(project) {
         // The include roots are derived from the packaged headers, so they have to exist first.
         dependsOn(packageHeadersTask)
         doLast {
-            def headersDestDir = file("${project.projectDir}/src/main/assets/headers")
             def overrideIncludeRoots = findCodegenOverrideIncludeRoots(headersDestDir, codegenName)
             if (overrideIncludeRoots) {
                 println "📦 Codegen header overrides for ${codegenName}: ${overrideIncludeRoots.join(', ')}"


### PR DESCRIPTION

## 📝 Description

Apps consuming the react-native-gesture-handler prebuilt fail to compile with:

    autolinking.cpp:52: error: unknown type name
    'RNGestureHandlerDetectorComponentDescriptor'

RNGH 3.x ships a hand-written header that shadows its codegen output

#430 

## What changed

### `packages/builder/gradle_init_scripts/add-publishing.gradle`

- Added `findCodegenOverrideIncludeRoots()`, which scans the packaged `assets/headers` tree for subdirectories carrying their own `react/renderer/components/<codegenName>/*.h` and returns them sorted, recovering the include-root information that flattening destroys.
- Added `findPackageCodegenOverrideRoots()`, which applies the same shape detection to the package sources to find override roots that lie outside every directory `packageCppHeaders` collects, skipping `build`/`node_modules`/`.cxx`/`.gradle` paths and any root already covered by a collected directory.
- `packageCppHeaders` now copies those extra roots into `assets/headers/<package-relative path>`, preserving the prefix instead of flattening them so they shadow rather than clobber the generated headers.
- `packageCppHeaders` now deletes `assets/headers` before repopulating it, so leftovers from an earlier run are neither packaged into the AAR nor mistaken for override include roots.
- `generateCMakeContent()` now takes the discovered override roots and emits them in `target_include_directories` ahead of `assets/headers`, mirroring the include order the library's own CMakeLists uses.
- `packageCodegenCMake` now declares `dependsOn(packageHeadersTask)`, since it derives the include roots from the directory that task fills.
- The `assets/headers` path is now a single `headersDestDir` variable shared by both tasks instead of a literal repeated in each.

### `packages/builder/build-library-android.ts`

- Extracted the `SHARED → STATIC` rewrite into a `CMAKE_STATIC_PATCHES` table and added an `OBJECT → STATIC` rule scoped to `react_codegen_*` targets, so hand-written codegen CMakeLists that declare an OBJECT library (react-native-reanimated) produce a linkable archive.
- Relaxed the early-exit precondition from "file contains `add_library` and `SHARED`" to just "file contains `add_library`", so OBJECT-only files are no longer skipped before patching.
- `patchCMakeListsToStatic()` now takes `hasCodegenConfig` and rethrows patch failures as fatal for libraries that publish a codegen AAR, instead of always warning and continuing.
- The success log now names which rewrites were applied rather than assuming `SHARED → STATIC`.

> note reanimated@4.5.0 with REASharedTransitionBoundaryComponentDescriptor work too

## 🧪 Testing

- AwesomeProject_86 (RN 0.86, new arch) build with new artifacts builds correctly
  - with rngh@+3 and reanimated@+4.5
- artifacts will be redeployed with proper codegen
