### PR TITLE
Fix Invariant Violation issue

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -276,4 +276,29 @@ To fix this, you need to exclude the `.rnrepo-cache` directories from Expo's fin
 
 See the [`.fingerprintignore` documentation](https://docs.expo.dev/versions/latest/sdk/fingerprint/#fingerprintignore) or [`fingerprint.config.js` documentation](https://docs.expo.dev/versions/latest/sdk/fingerprint/#fingerprintconfigjs) for more details.
 
+### Metro `Invariant Violation` for `.rnrepo-cache` Directory
+
+#### Problem Description
+After running `pod install`, Metro may crash with an `Invariant Violation` error when it detects a change inside the `.rnrepo-cache` directory created by the RNRepo plugin:
+
+```
+Invariant Violation: Detected addition or modification of file <path>/.rnrepo-cache/Current, but it is tracked as a non-empty directory
+```
+
+This happens because Metro's `TreeFS` initially sees `.rnrepo-cache/Current` as a directory (it is an Xcode-style symlink pointing to the currently active xcframework version) and then receives a filesystem event that treats it as a file. The mismatch causes Metro to throw.
+
+#### Solution
+Cleaning metro/watchman cache usually helps:
+
+```bash
+npx watchman watch-del-all
+npx metro restart --reset-cache # or for expo: npx expo start -c
+```
+
+But if issue still persist, you can exclude the `.rnrepo-cache` directories from Metro's file watcher by adding them to the `blockList` in your `metro.config.js`:
+
+```js
+config.resolver.blockList = [...existing, /.*[\\/]\.rnrepo-cache[\\/].*/];
+```
+
 ---

--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Route `org.rnrepo.public` artifacts exclusively to the RNRepo Maven repository so a Maven Central timeout no longer fails the build (#424)
+- Keep `.rnrepo-cache/Current` a directory of symlinks into `Debug`/`Release` so switching configuration no longer turns a watched directory into a symlink and crashes Metro with `Invariant Violation` (#433)
 
 ## [0.2.1] - 2026-07-16
 

--- a/packages/build-tools/cocoapods-plugin/README.md
+++ b/packages/build-tools/cocoapods-plugin/README.md
@@ -52,12 +52,14 @@ The plugin hooks into the CocoaPods lifecycle:
 
 2. **Dependency Resolution** (modifies pod specs):
    - Configures pod specifications to use pre-built xcframeworks instead of source files
-   - Points vendored_frameworks to `.rnrepo-cache/Current/` (symlink created at build time)
+   - Points vendored_frameworks to `.rnrepo-cache/Current/`, a real directory holding one symlink per xcframework
 
 3. **Post-Install Hook**:
    - Adds build phase scripts to each pod target using pre-built frameworks
-   - Scripts run before compilation and create a `Current` symlink pointing to `Debug` or `Release` based on `$CONFIGURATION`
+   - Scripts run before compilation and repoint the symlinks in `Current` at `Debug` or `Release`, based on whether `DEBUG=1` is defined
    - Ensures the correct framework configuration is used at build time
+
+   `Current` is always a directory and the xcframeworks inside it are always symlinks — neither ever changes type. Metro watches `node_modules` unconditionally and crashes with `tracked as a non-empty directory` if a path it holds as a directory becomes a symlink.
 
 ### Framework Storage
 
@@ -71,7 +73,8 @@ node_modules/
           │   └── {package-name}.xcframework/
           ├── Release/
           │   └── {package-name}.xcframework/
-          └── Current/  (symlink created at build time → Debug or Release)
+          └── Current/
+              └── {package-name}.xcframework  (symlink → ../Debug or ../Release)
 ```
 
 ### Cache directory

--- a/packages/build-tools/cocoapods-plugin/lib/plugin.rb
+++ b/packages/build-tools/cocoapods-plugin/lib/plugin.rb
@@ -325,15 +325,26 @@ module Pod
         # Find the xcframework (name may differ from pod name due to sanitization)
         cache_dir = File.join(node_modules_path, '.rnrepo-cache')
 
-        # Create Current directory
+        # Create the Current directory holding a symlink per xcframework.
+        #
+        # Current itself must stay a real directory and the xcframeworks inside
+        # it must stay symlinks for the whole lifetime of the install: Metro
+        # watches node_modules unconditionally and throws Invariant Violation
+        # if a path it holds as a directory turns into a symlink. This is what
+        # happened when the build phase replaced a copied Current with a symlink.
         current_link = File.join(cache_dir, 'Current')
-        FileUtils.rm_f(current_link) if File.exist?(current_link)
+        FileUtils.rm_rf(current_link)
+        FileUtils.mkdir_p(current_link)
+
         # Prefer Debug for development
         debug_cache_dir = File.join(cache_dir, 'Debug')
-        FileUtils.cp_r(debug_cache_dir, current_link)
-        CocoapodsRnrepo::Logger.log "  Copied to Current directory from Debug"
+        Dir.glob(File.join(debug_cache_dir, '*.xcframework')).each do |xcframework|
+          name = File.basename(xcframework)
+          FileUtils.ln_s(File.join('..', 'Debug', name), File.join(current_link, name))
+        end
+        CocoapodsRnrepo::Logger.log "  Linked Current directory to Debug"
 
-        # Look for xcframeworks in Current (which is a copy of Debug or Release)
+        # Look for xcframeworks in Current (symlinks into Debug or Release)
         xcframeworks = Dir.glob(File.join(current_link, "*.xcframework"))
 
         if xcframeworks.empty?
@@ -512,16 +523,17 @@ def rnrepo_post_install(installer_context)
       fi
       echo "RNREPO: Switching to ${TARGET_DIR} configuration"
 
-      # Remove existing Current link/directory if it exists
-      if [ -L "${CURRENT_LINK}" ] || [ -e "${CURRENT_LINK}" ]; then
-        rm -rf "${CURRENT_LINK}"
-      fi
-
       # Ensure the target directory is created (should exist, but just in case)
       mkdir -p "${CACHE_DIR}/${TARGET_DIR}"
 
-      # Create symlink to the appropriate configuration
-      ln -sf "${TARGET_DIR}" "${CURRENT_LINK}"
+      # Point each xcframework at the selected configuration
+      for XCFRAMEWORK in "${CACHE_DIR}/${TARGET_DIR}"/*.xcframework; do
+        [ -e "${XCFRAMEWORK}" ] || continue
+        NAME="$(basename "${XCFRAMEWORK}")"
+        # -n so an existing symlink is replaced instead of resolved and
+        # written into
+        ln -sfn "../${TARGET_DIR}/${NAME}" "${CURRENT_LINK}/${NAME}"
+      done
 
       echo "RNREPO: Selected ${TARGET_DIR} configuration for ${PODS_TARGET_SRCROOT}"
     SCRIPT


### PR DESCRIPTION
## 📝 Description

`pod install` created `.rnrepo-cache/Current` as a real directory (`cp_r` of `Debug`), and the
injected script then deleted it and put a symlink in its place on every build throwing metro error - Invariant Violation. 

`Current` is now a real directory for the whole lifetime of the install, and each xcframework
inside it is a symlink into `Debug`/`Release`. The build phase repoints those symlinks instead of
swapping `Current` itself, so no path ever changes node type and the invariant cannot fire.


## 🧪 Testing

expo@55 app switching ios debug/release and in rngh repo
