### PR TITLE
Strip codegen from final apk

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Route `org.rnrepo.public` artifacts exclusively to the RNRepo Maven repository so a Maven Central timeout no longer fails the build (#424)
+- Keep the prebuilt codegen payload the `-codegen` AARs carry under `assets/` out of the app's APK/AAB (#434)
 
 ## [0.2.1] - 2026-07-16
 

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -1,5 +1,7 @@
 package org.rnrepo.tools.prebuilds
 
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import groovy.json.JsonSlurper
@@ -8,6 +10,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
@@ -159,6 +162,11 @@ class PrebuildsPlugin : Plugin<Project> {
 
             // Configure pickFirsts for packages with native libraries that may have duplicates
             configurePickFirsts(project, extension.supportedPackages)
+
+            // Keep the codegen payload the -codegen AARs carry under assets/ out of the app
+            if (extension.supportedPackages.any { it.hasCodegen }) {
+                configureCodegenAssetsStripping(project, codegenConfig)
+            }
 
             // Add dependency on generating codegen schema for each library that needs it
             // Skip packages with hasCodegen=true since they use prebuilt codegen artifacts
@@ -335,6 +343,40 @@ class PrebuildsPlugin : Plugin<Project> {
         if (lastPart == null) return version
         val upperBound = version.substring(0, lastDot + 1) + (lastPart + 1)
         return "[$version,$upperBound)"
+    }
+
+    /**
+     * Wires [StripCodegenAssetsTask] into every variant so the codegen payload the `-codegen` AARs
+     * carry under `assets/` never reaches the APK. The artifacts stay on the app's classpath for
+     * their classes and `.so` files, and [ExtractPrebuiltsTask] keeps reading the payload straight
+     * from the `codegenPrebuilts` configuration, so only packaging is affected.
+     */
+    private fun configureCodegenAssetsStripping(
+        project: Project,
+        codegenConfig: Configuration,
+    ) {
+        val androidComponents = project.extensions.findByType(ApplicationAndroidComponentsExtension::class.java)
+        if (androidComponents == null) {
+            logger.info(
+                "Android components extension not found in project ${project.name}, " +
+                    "prebuilt codegen payload might be packaged into the app.",
+            )
+            return
+        }
+
+        androidComponents.onVariants { variant ->
+            val stripTask =
+                project.tasks.register(
+                    "strip${variant.name.replaceFirstChar { it.uppercase() }}CodegenAssets",
+                    StripCodegenAssetsTask::class.java,
+                ) {
+                    it.codegenArtifacts.from(codegenConfig)
+                }
+            variant.artifacts
+                .use(stripTask)
+                .wiredWithDirectories(StripCodegenAssetsTask::inputAssets, StripCodegenAssetsTask::outputAssets)
+                .toTransform(SingleArtifact.ASSETS)
+        }
     }
 
     /**

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/StripCodegenAssetsTask.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/StripCodegenAssetsTask.kt
@@ -1,0 +1,112 @@
+package org.rnrepo.tools.prebuilds
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.util.zip.CRC32
+import java.util.zip.ZipFile
+
+/**
+ * Drops the prebuilt codegen payload from the assets that get packaged into the app.
+ *
+ * An AAR can only carry arbitrary files under `assets/`, so that is where the `-codegen` artifacts
+ * ship their per-ABI static libraries, headers and cmake glue. [ExtractPrebuiltsTask] unzips those
+ * artifacts itself from the `codegenPrebuilts` configuration, so nothing reads them from the merged
+ * assets — but AGP still merges them into the APK, where they are worth hundreds of megabytes.
+ *
+ * Entries are matched by their exact path inside the codegen AARs rather than by name, so assets
+ * that merely share a directory name with the payload (`headers/`, `meta/`, ...) survive.
+ */
+abstract class StripCodegenAssetsTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val codegenArtifacts: ConfigurableFileCollection
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputAssets: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val outputAssets: DirectoryProperty
+
+    @TaskAction
+    fun execute() {
+        val outDir = outputAssets.get().asFile
+        if (outDir.exists()) outDir.deleteRecursively()
+        outDir.mkdirs()
+
+        val inDir = inputAssets.get().asFile
+        if (!inDir.isDirectory) return
+
+        val payload = collectPayload()
+
+        inDir.walkTopDown().filter { it.isFile }.forEach { file ->
+            val relativePath = file.toRelativeString(inDir).replace(File.separatorChar, '/')
+            if (payload[relativePath]?.any { it.matches(file) } == true) {
+                return@forEach
+            }
+            val target = File(outDir, relativePath)
+            target.parentFile.mkdirs()
+            file.copyTo(target, overwrite = true)
+        }
+    }
+
+    /**
+     * Every `assets/` entry of every resolved codegen artifact, keyed by its path relative to
+     * `assets/` — the exact shape the merged assets directory uses.
+     */
+    private fun collectPayload(): Map<String, Set<PayloadEntry>> {
+        val payload = mutableMapOf<String, MutableSet<PayloadEntry>>()
+        codegenArtifacts.files.forEach { artifact ->
+            if (!artifact.isFile) return@forEach
+            ZipFile(artifact).use { zip ->
+                zip
+                    .entries()
+                    .asSequence()
+                    .filter { !it.isDirectory && it.name.startsWith(ASSETS_PREFIX) }
+                    .forEach { entry ->
+                        // Every artifact ships its own cmake/meta files at the same path, so one path
+                        // maps to as many candidates as there are codegen packages in the build.
+                        payload
+                            .getOrPut(entry.name.removePrefix(ASSETS_PREFIX)) { mutableSetOf() }
+                            .add(PayloadEntry(entry.size, entry.crc))
+                    }
+            }
+        }
+        return payload
+    }
+
+    /**
+     * Size and checksum of one packaged entry. A merged asset is only dropped when it is byte-for-byte
+     * the entry we shipped: an app that happens to own an asset at the same path overrides the
+     * library's during merging, and that file has to survive.
+     */
+    private data class PayloadEntry(
+        val size: Long,
+        val crc: Long,
+    ) {
+        fun matches(file: File): Boolean {
+            if (file.length() != size) return false
+            val checksum = CRC32()
+            file.inputStream().buffered().use { stream ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val read = stream.read(buffer)
+                    if (read < 0) break
+                    checksum.update(buffer, 0, read)
+                }
+            }
+            return checksum.value == crc
+        }
+    }
+
+    private companion object {
+        const val ASSETS_PREFIX = "assets/"
+    }
+}

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/StripCodegenAssetsTaskTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/StripCodegenAssetsTaskTest.kt
@@ -1,0 +1,127 @@
+package org.rnrepo.tools.prebuilds
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StripCodegenAssetsTaskTest {
+    @TempDir
+    lateinit var testDir: File
+
+    private lateinit var mergedAssets: File
+    private lateinit var strippedAssets: File
+
+    @BeforeEach
+    fun setUp() {
+        mergedAssets = File(testDir, "merged").also { it.mkdirs() }
+        strippedAssets = File(testDir, "stripped")
+    }
+
+    @Test
+    fun `strips the codegen payload from the merged assets`() {
+        val aar =
+            aarWithAssets(
+                "codegen.aar",
+                "relwithdebinfo/arm64-v8a/libreact_codegen_rnscreens.a" to "static library bytes",
+                "headers/react/renderer/components/rnscreens/Props.h" to "generated header",
+                "meta/codegen_name.txt" to "rnscreens",
+            )
+        mergedAsset("relwithdebinfo/arm64-v8a/libreact_codegen_rnscreens.a", "static library bytes")
+        mergedAsset("headers/react/renderer/components/rnscreens/Props.h", "generated header")
+        mergedAsset("meta/codegen_name.txt", "rnscreens")
+
+        runTask(aar)
+
+        assertThat(strippedAssets.walkTopDown().filter { it.isFile }.toList()).isEmpty()
+    }
+
+    @Test
+    fun `keeps assets the app owns`() {
+        val aar = aarWithAssets("codegen.aar", "meta/codegen_name.txt" to "rnscreens")
+        mergedAsset("meta/codegen_name.txt", "rnscreens")
+        mergedAsset("fonts/Inter.ttf", "font bytes")
+
+        runTask(aar)
+
+        assertThat(strippedAsset("fonts/Inter.ttf")).exists()
+        assertThat(strippedAsset("meta/codegen_name.txt")).doesNotExist()
+    }
+
+    @Test
+    fun `keeps an app asset that shadows a payload path with different content`() {
+        val aar = aarWithAssets("codegen.aar", "meta/npm_name.txt" to "react-native-screens")
+        // The app's own asset wins the merge, so what lands here is not what we shipped.
+        mergedAsset("meta/npm_name.txt", "app owned value")
+
+        runTask(aar)
+
+        assertThat(strippedAsset("meta/npm_name.txt")).hasContent("app owned value")
+    }
+
+    @Test
+    fun `strips a path that several codegen artifacts ship with different content`() {
+        // Every codegen artifact carries its own cmake/CMakeLists.txt, so only one of them can match
+        // the merged file — the others must not make the task give up on it.
+        val screens = aarWithAssets("screens.aar", "cmake/CMakeLists.txt" to "add_library(rnscreens)")
+        val gestures = aarWithAssets("gestures.aar", "cmake/CMakeLists.txt" to "add_library(rngesturehandler)")
+        mergedAsset("cmake/CMakeLists.txt", "add_library(rngesturehandler)")
+
+        runTask(screens, gestures)
+
+        assertThat(strippedAsset("cmake/CMakeLists.txt")).doesNotExist()
+    }
+
+    @Test
+    fun `copies everything when no codegen artifacts are resolved`() {
+        mergedAsset("fonts/Inter.ttf", "font bytes")
+
+        runTask()
+
+        assertThat(strippedAsset("fonts/Inter.ttf")).hasContent("font bytes")
+    }
+
+    private fun runTask(vararg codegenArtifacts: File) {
+        val project = ProjectBuilder.builder().withProjectDir(testDir).build()
+        val task = project.tasks.create("stripCodegenAssets", StripCodegenAssetsTask::class.java)
+        task.codegenArtifacts.from(*codegenArtifacts)
+        task.inputAssets.set(mergedAssets)
+        task.outputAssets.set(strippedAssets)
+
+        task.execute()
+    }
+
+    private fun mergedAsset(
+        path: String,
+        content: String,
+    ) = File(mergedAssets, path).apply {
+        parentFile.mkdirs()
+        writeText(content)
+    }
+
+    private fun strippedAsset(path: String) = File(strippedAssets, path)
+
+    private fun aarWithAssets(
+        name: String,
+        vararg assets: Pair<String, String>,
+    ): File {
+        val aar = File(testDir, name)
+        ZipOutputStream(aar.outputStream().buffered()).use { zip ->
+            zip.putNextEntry(ZipEntry("classes.jar"))
+            zip.write("not an asset".toByteArray())
+            zip.closeEntry()
+            assets.forEach { (path, content) ->
+                zip.putNextEntry(ZipEntry("assets/$path"))
+                zip.write(content.toByteArray())
+                zip.closeEntry()
+            }
+        }
+        return aar
+    }
+}


### PR DESCRIPTION
## 📝 Description

The `-codegen` AARs carry their prebuilt payload under `assets/` - per-ABI
static libraries, headers and cmake glue - because that is the only place an
AAR can hold arbitrary files. AGP merges library assets into the app verbatim,
so every consumer app was shipping that payload inside its APK/AAB.

For `react-native-screens` alone this is ~175 MB uncompressed: eight
`libreact_codegen_rnscreens.a` archives (4 ABIs × debug/relwithdebinfo), 53
headers, `cmake/CMakeLists.txt` and two `meta/*.txt` files. Apps with several
prebuilt libraries multiply that.

`StripCodegenAssetsTask` is wired into every variant as a transform of
`SingleArtifact.ASSETS`. Entries are matched by their exact path inside the
codegen AARs **and** by size + CRC, so an app asset that happens to shadow a
payload path (`meta/`, `headers/`, `debug/` are generic directory names) wins
the merge and survives. Only packaging is affected - the artifacts stay on the
app's classpath for their classes and `.so` files.

Info #431 (Android side)

## 🧪 Testing

Verified end-to-end on a minimal Expo 56 / RN 0.85.3 app with one prebuilt
library (debug APK, arm64-v8a):

| build                    | APK size    |
|--------------------------|-------------|
| without RNRepo           | 78 996 286 B |
| with RNRepo, before fix  | 108 010 668 B |
| with RNRepo, after fix   | 75 604 709 B |

Post-fix APK contains only `assets/app.config`; zero `.a` and zero header files
remain. `lib/`, `res/` and the dex files are unchanged relative to the pre-fix
build.

**Steps to reproduce:**
1. Create an Expo 56 / RN 0.85.3 app and add
   `@rnrepo/expo-config-plugin`.
2. `npx expo run:android` and note the size of
   `android/app/build/outputs/apk/debug/app-debug.apk`.
3. Unzip it and inspect `assets/` - before this change it contains
   `relwithdebinfo/` and `debug/` trees with `.a` archives; after, only
   `app.config`.
