### PR TITLE
feat: improve logging to distinguish between denied and unavailable

### DIFF
--- a/packages/build-tools/CHANGELOG.md
+++ b/packages/build-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Added
+- Log distinction between denied and unavailable in Android (#436)
+
 ## [0.2.2] - 2026-08-03
 
 ### Changed

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -58,7 +58,7 @@ private class PrefixedLogger(
     fun debug(message: String) = delegate.debug("[📦 RNRepo] $message")
 }
 
-private enum class FallbackReason(
+internal enum class FallbackReason(
     val icon: String,
     val heading: String,
 ) {
@@ -68,7 +68,7 @@ private enum class FallbackReason(
     DEPENDENCY("⛓️", "Packages with a prebuilt available, kept on sources to stay compatible with other packages"),
 }
 
-private class FallbackPackages {
+internal class FallbackPackages {
     private val byReason =
         FallbackReason.values().associateWith {
             java.util.concurrent.ConcurrentHashMap<PackageItem, String>()
@@ -700,27 +700,27 @@ class PrebuildsPlugin : Plugin<Project> {
     private fun toGradleName(packageName: String): String = packageName.replace("@", "").replace("/", "_")
 
     /**
-     * Checks if a specific package is not in the deny list or excluded by other rules.
+     * Checks whether the package is in the deny list or excluded by a built-in rule.
      *
      * @param packageName The name of the package to check.
      * @param extension The PackagesManager instance containing the deny list.
      *
-     * @return True if the package is not denied, false otherwise.
+     * @return A short description of which rule denied the package, or null when it is not denied.
      */
-    private fun isPackageNotDenied(
+    private fun deniedReason(
         packageName: String,
         extension: PackagesManager,
-    ): Boolean {
+    ): String? {
         if (extension.denyList.contains(packageName)) {
             logger.info("Package $packageName is in deny list, skipping in RNRepo.")
-            return false
+            return "deny list"
         }
         if (packageName.startsWith("expo") && packageName != "expo-modules-core") {
             logger.info("Package $packageName is an Expo package, skipping in RNRepo.")
-            return false
+            return "built-in Expo exclusion"
         }
         logger.info("Package $packageName is not denied.")
-        return true
+        return null
     }
 
     private fun resolveRNRepoRepositories(repositories: RepositoryHandler): List<MavenArtifactRepository> {
@@ -1087,12 +1087,20 @@ class PrebuildsPlugin : Plugin<Project> {
         }
     }
 
-    private fun isSpecificCheckPassed(
+    /**
+     * Runs the package-specific compatibility check.
+     *
+     * May mutate [PackageItem.classifier] (e.g. append the worklets classifier), so it must run
+     * before the availability probe that looks the classifier up.
+     *
+     * @return A short description of why the check failed, or null when the package passed.
+     */
+    private fun specificCheckFailureReason(
         packageItem: PackageItem,
         extension: PackagesManager,
         supportedPackages: Set<PackageItem>,
         project: Project,
-    ): Boolean {
+    ): String? {
         when (packageItem.name) {
             "react-native-gesture-handler" -> {
                 val isReanimatedPresent = extension.projectPackages.any { it.name == "react-native-reanimated" }
@@ -1100,7 +1108,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-gesture-handler: react-native-reanimated not found in project, using react-native-gesture-handler from sources.",
                     )
-                    return false
+                    return "requires react-native-reanimated in the project"
                 }
             }
             "react-native-reanimated" -> {
@@ -1108,13 +1116,13 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-reanimated: Version ${packageItem.version} is 3.x, no worklets package needed.",
                     )
-                    return true
+                    return null
                 }
                 if (isVersionAtLeast(packageItem.version, "4.3.0")) {
                     logger.info(
                         "react-native-reanimated: Version ${packageItem.version} is 4.3.0 or higher, no worklets classifier needed.",
                     )
-                    return true
+                    return null
                 }
                 val workletsItem = extension.projectPackages.find { it.name == "react-native-worklets" }
                 if (workletsItem != null) {
@@ -1126,7 +1134,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-reanimated: react-native-worklets not found in project, using react-native-reanimated from sources.",
                     )
-                    return false
+                    return "requires react-native-worklets in the project"
                 }
             }
             "expensify_react-native-live-markdown" -> {
@@ -1140,7 +1148,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-live-markdown: react-native-worklets not found in project, using react-native-live-markdown from sources.",
                     )
-                    return false
+                    return "requires react-native-worklets in the project"
                 }
             }
             "expo-modules-core" -> {
@@ -1148,7 +1156,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "expo-modules-core: Debug mode is not supported for expo-modules-core, using expo-modules-core from sources.",
                     )
-                    return false
+                    return "prebuilt is not supported in debug builds"
                 }
             }
             "react-native-audio-api" -> {
@@ -1162,7 +1170,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-audio-api: react-native-worklets not found in project, using react-native-audio-api from sources.",
                     )
-                    return false
+                    return "requires react-native-worklets in the project"
                 }
             }
             "react-native-worklets" -> {
@@ -1175,7 +1183,7 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.info(
                         "react-native-worklets: Release build, prebuilt worklets can be used regardless of expo-modules-core support.",
                     )
-                    return true
+                    return null
                 }
                 val isExpo55OrLaterPresent =
                     extension.projectPackages.any { pkg ->
@@ -1191,11 +1199,11 @@ class PrebuildsPlugin : Plugin<Project> {
                     logger.lifecycle(
                         "react-native-worklets: Expo 55 or later found in project, which has react-native-worklets as a dependency with hardcoded native library path, using react-native-worklets from sources.",
                     )
-                    return false
+                    return "Expo 55+ debug builds need worklets from sources while expo-modules-core is not prebuilt"
                 }
             }
         }
-        return true
+        return null
     }
 
     private fun removeCppDependenciesFromSupportedPackages(
@@ -1316,49 +1324,51 @@ class PrebuildsPlugin : Plugin<Project> {
         elseClosure: () -> Unit,
         project: Project,
     ) {
-        val isDenied = !isPackageNotDenied(packageItem.name, extension)
-        val checkFailed = !isSpecificCheckPassed(packageItem, extension, supportedPackages, project)
-        val isUnavailable = !isPackageAvailable(packageItem, extension.reactNativeVersion, httpRepositories)
-
         // A package can trip more than one check (an Expo package is denied *and* has no artifact
-        // published). Report the one the user has to act on first: a deny rule makes the missing
-        // artifact irrelevant, and a failed compatibility check means the artifact was never wanted.
-        val fallbackReason =
-            when {
-                isDenied -> FallbackReason.DENIED
-                checkFailed -> FallbackReason.INCOMPATIBLE
-                isUnavailable -> FallbackReason.UNAVAILABLE
-                else -> null
-            }
+        // published). Check in the order the user has to act on: a deny rule makes the missing
+        // artifact irrelevant, and a failed compatibility check means the artifact was never
+        // wanted. Short-circuiting also skips the availability probe's HTTP round-trips for
+        // packages that are already rejected. The probe must stay last for another reason too:
+        // specificCheckFailureReason sets the classifier the probe looks up.
+        val fallback: Pair<FallbackReason, String>? =
+            deniedReason(packageItem.name, extension)
+                ?.let { FallbackReason.DENIED to it }
+                ?: specificCheckFailureReason(packageItem, extension, supportedPackages, project)
+                    ?.let { FallbackReason.INCOMPATIBLE to it }
+                ?: if (isPackageAvailable(packageItem, extension.reactNativeVersion, httpRepositories)) {
+                    null
+                } else {
+                    FallbackReason.UNAVAILABLE to ""
+                }
 
-        when (fallbackReason) {
-            null -> elseClosure()
-            else -> {
-                fallbackPackages.add(fallbackReason, packageItem)
-                // Spell out which check rejected the package: a deny rule and a missing artifact look
-                // identical from the build log otherwise, and they need opposite fixes (edit rnrepo
-                // config vs. update the tools/prebuilds version).
-                val reason =
-                    when (fallbackReason) {
-                        FallbackReason.DENIED ->
-                            "${packageItem.npmName} is denied by RNRepo configuration (deny list, allow list or built-in " +
-                                "exclusion), so no prebuilt was requested for it."
-                        FallbackReason.INCOMPATIBLE ->
-                            "${packageItem.npmName} did not pass its package-specific compatibility check " +
-                                "(see the reason logged above, or re-run with --info)."
-                        else ->
-                            "${packageItem.npmName}@${packageItem.version}${packageItem.classifier} is unavailable: no prebuilt " +
-                                "artifact for React Native ${extension.reactNativeVersion} was found in the configured RNRepo " +
-                                "repositories. It may not be published yet for this combination — check for a newer @rnrepo/build-tools."
-                    }
-                removeCppDependenciesFromSupportedPackages(
-                    packageItem,
-                    supportedPackages,
-                    fallbackPackages,
-                    reason,
-                )
-            }
+        if (fallback == null) {
+            elseClosure()
+            return
         }
+        val (fallbackReason, detail) = fallback
+        fallbackPackages.add(fallbackReason, packageItem, detail)
+        // Spell out which check rejected the package: a deny rule and a missing artifact look
+        // identical from the build log otherwise, and they need opposite fixes (edit rnrepo
+        // config vs. update the tools/prebuilds version).
+        val reason =
+            when (fallbackReason) {
+                FallbackReason.DENIED ->
+                    "${packageItem.npmName} is denied by RNRepo configuration ($detail), so no prebuilt was requested for it."
+                FallbackReason.INCOMPATIBLE ->
+                    "${packageItem.npmName} did not pass its package-specific compatibility check: $detail."
+                FallbackReason.UNAVAILABLE ->
+                    "${packageItem.npmName}@${packageItem.version}${packageItem.classifier} is unavailable: no prebuilt " +
+                        "artifact for React Native ${extension.reactNativeVersion} was found in the configured RNRepo " +
+                        "repositories. It may not be published yet for this combination — check for a newer @rnrepo/build-tools."
+                FallbackReason.DEPENDENCY ->
+                    error("DEPENDENCY is only assigned when a package is removed for another package's sake")
+            }
+        removeCppDependenciesFromSupportedPackages(
+            packageItem,
+            supportedPackages,
+            fallbackPackages,
+            reason,
+        )
     }
 
     private fun printList(
@@ -1374,8 +1384,7 @@ class PrebuildsPlugin : Plugin<Project> {
     }
 
     /**
-     * Same as [printList], but appends the per-package detail explaining the fallback, e.g.
-     * `- ⛓️ react-native-reanimated@4.3.1 (depends on react-native-worklets)`.
+     * Same as [printList], but appends the per-package detail explaining the fallback
      */
     private fun printFallbackList(
         packages: Map<PackageItem, String>,
@@ -1440,11 +1449,10 @@ class PrebuildsPlugin : Plugin<Project> {
         extension.supportedPackages = supportedPackages
         logger.lifecycle("Found the following supported prebuilt packages:${printList(extension.supportedPackages, "📦")}")
         if (fallbackPackages.isEmpty()) {
-            logger.lifecycle("Packages that fallback to building from sources:${printList(emptyList())}")
+            logger.lifecycle("Packages that fallback to building from sources: None")
             return
         }
-        // One list per reason, so it is clear whether a package needs a config change, a newer
-        // @rnrepo/build-tools, or nothing at all (it follows a dependency that is not prebuilt).
+        // One list per reason, so it is clear whether a package fallback
         FallbackReason.values().forEach { reason ->
             val packages = fallbackPackages.get(reason)
             if (packages.isNotEmpty()) {

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -1165,12 +1165,11 @@ class PrebuildsPlugin : Plugin<Project> {
         packageItem: PackageItem,
         supportedPackages: MutableSet<PackageItem>,
         unavailablePackages: MutableSet<PackageItem>,
-        allDependentPackageAreSupported: List<PackageItem> = emptyList(),
+        reason: String,
     ) {
         if (PACKAGES_WITH_CPP[packageItem.name].isNullOrEmpty()) {
             return
         }
-        val dependentPackagePattern = PACKAGES_WITH_CPP[packageItem.name].orEmpty().joinToString("|") { it }
         val packagesToCheckRegex = PACKAGES_WITH_CPP[packageItem.name]?.map { it.toRegex() } ?: emptyList()
         val packagesToRemove =
             supportedPackages.filter { supportedPackage ->
@@ -1180,14 +1179,6 @@ class PrebuildsPlugin : Plugin<Project> {
             }
         supportedPackages.removeAll(packagesToRemove)
         unavailablePackages.addAll(packagesToRemove)
-        val reason =
-            if (allDependentPackageAreSupported.isEmpty()) {
-                "${packageItem.npmName} is denied or unavailable."
-            } else {
-                "Unavailable dependent packages found for ${packageItem.npmName} matching pattern '$dependentPackagePattern': ${printList(
-                    allDependentPackageAreSupported,
-                )}"
-            }
         logger.lifecycle(
             "$reason\nRemoving packages that depend on ${packageItem.npmName} (fallback to sources) from supported packages: ${printList(
                 packagesToRemove,
@@ -1203,7 +1194,8 @@ class PrebuildsPlugin : Plugin<Project> {
         projectPackages: Set<PackageItem>,
     ) {
         logger.info("${packageItem.npmName} is supported, checking if all packages depending on it are supported.")
-        PACKAGES_WITH_CPP.get(packageItem.name)?.forEach { dependentPackagePattern ->
+        val dependentPackagePatterns = PACKAGES_WITH_CPP[packageItem.name].orEmpty()
+        dependentPackagePatterns.forEach { dependentPackagePattern ->
             val dependentPackagePatternRegex = dependentPackagePattern.toRegex()
             val isPackagePresentInProject =
                 project.rootProject.allprojects.any { subproject ->
@@ -1221,11 +1213,13 @@ class PrebuildsPlugin : Plugin<Project> {
                     .filterNot { dep -> supportedPackages.any { it.name == dep.name } }
             if (allDependentPackageAreSupported.isNotEmpty()) {
                 unavailablePackages.add(packageItem)
+                val patterns = dependentPackagePatterns.joinToString("|")
                 removeCppDependenciesFromSupportedPackages(
                     packageItem,
                     supportedPackages,
                     unavailablePackages,
-                    allDependentPackageAreSupported,
+                    "Unavailable dependent packages found for ${packageItem.npmName} matching pattern " +
+                        "'$patterns': ${printList(allDependentPackageAreSupported)}",
                 )
                 return
             }
@@ -1286,10 +1280,27 @@ class PrebuildsPlugin : Plugin<Project> {
                 if (isUnavailable) {
                     unavailablePackages.add(packageItem)
                 }
+                // Report which of the three checks rejected the package: a deny/allow list rule and a
+                // missing artifact look identical from the build log otherwise, and they need opposite
+                // fixes (edit rnrepo config vs. update the tools/prebuilds version).
+                val reason =
+                    when {
+                        isDenied ->
+                            "${packageItem.npmName} is denied by RNRepo configuration (deny list, allow list or built-in " +
+                                "exclusion), so no prebuilt was requested for it."
+                        checkFailed ->
+                            "${packageItem.npmName} did not pass its package-specific compatibility check " +
+                                "(see the reason logged above, or re-run with --info)."
+                        else ->
+                            "${packageItem.npmName}@${packageItem.version}${packageItem.classifier} is unavailable: no prebuilt " +
+                                "artifact for React Native ${extension.reactNativeVersion} was found in the configured RNRepo " +
+                                "repositories. It may not be published yet for this combination — check for a newer @rnrepo/build-tools."
+                    }
                 removeCppDependenciesFromSupportedPackages(
                     packageItem,
                     supportedPackages,
                     unavailablePackages,
+                    reason,
                 )
             }
             else -> elseClosure()

--- a/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
+++ b/packages/build-tools/gradle-plugin/src/main/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPlugin.kt
@@ -58,6 +58,43 @@ private class PrefixedLogger(
     fun debug(message: String) = delegate.debug("[📦 RNRepo] $message")
 }
 
+private enum class FallbackReason(
+    val icon: String,
+    val heading: String,
+) {
+    DENIED("🚫", "Packages denied by configuration (deny/allow list or built-in rule)"),
+    UNAVAILABLE("❓", "Packages with no matching prebuilt artifact published"),
+    INCOMPATIBLE("⚠️", "Packages that failed a compatibility check"),
+    DEPENDENCY("⛓️", "Packages with a prebuilt available, kept on sources to stay compatible with other packages"),
+}
+
+private class FallbackPackages {
+    private val byReason =
+        FallbackReason.values().associateWith {
+            java.util.concurrent.ConcurrentHashMap<PackageItem, String>()
+        }
+
+    fun add(
+        reason: FallbackReason,
+        packageItem: PackageItem,
+        detail: String = "",
+    ) {
+        byReason.getValue(reason)[packageItem] = detail
+    }
+
+    fun addAll(
+        reason: FallbackReason,
+        packages: Collection<PackageItem>,
+        detail: String = "",
+    ) {
+        packages.forEach { add(reason, it, detail) }
+    }
+
+    fun get(reason: FallbackReason): Map<PackageItem, String> = byReason.getValue(reason)
+
+    fun isEmpty(): Boolean = byReason.values.all { it.isEmpty() }
+}
+
 open class PackagesManager {
     var projectPackages: Set<PackageItem> = mutableSetOf()
     var supportedPackages: Set<PackageItem> = mutableSetOf()
@@ -1164,13 +1201,10 @@ class PrebuildsPlugin : Plugin<Project> {
     private fun removeCppDependenciesFromSupportedPackages(
         packageItem: PackageItem,
         supportedPackages: MutableSet<PackageItem>,
-        unavailablePackages: MutableSet<PackageItem>,
+        fallbackPackages: FallbackPackages,
         reason: String,
     ) {
-        if (PACKAGES_WITH_CPP[packageItem.name].isNullOrEmpty()) {
-            return
-        }
-        val packagesToCheckRegex = PACKAGES_WITH_CPP[packageItem.name]?.map { it.toRegex() } ?: emptyList()
+        val packagesToCheckRegex = PACKAGES_WITH_CPP[packageItem.name].orEmpty().map { it.toRegex() }
         val packagesToRemove =
             supportedPackages.filter { supportedPackage ->
                 packagesToCheckRegex.any { regex ->
@@ -1178,10 +1212,17 @@ class PrebuildsPlugin : Plugin<Project> {
                 }
             }
         supportedPackages.removeAll(packagesToRemove)
-        unavailablePackages.addAll(packagesToRemove)
+        fallbackPackages.addAll(FallbackReason.DEPENDENCY, packagesToRemove, "depends on ${packageItem.npmName}")
+        // Only worth a lifecycle line when it drags other packages down with it; otherwise the
+        // package just shows up under its reason in the summary printed at the end.
+        if (packagesToRemove.isEmpty()) {
+            logger.info(reason)
+            return
+        }
         logger.lifecycle(
             "$reason\nRemoving packages that depend on ${packageItem.npmName} (fallback to sources) from supported packages: ${printList(
                 packagesToRemove,
+                FallbackReason.DEPENDENCY.icon,
             )}",
         )
     }
@@ -1190,7 +1231,7 @@ class PrebuildsPlugin : Plugin<Project> {
         packageItem: PackageItem,
         project: Project,
         supportedPackages: MutableSet<PackageItem>,
-        unavailablePackages: MutableSet<PackageItem>,
+        fallbackPackages: FallbackPackages,
         projectPackages: Set<PackageItem>,
     ) {
         logger.info("${packageItem.npmName} is supported, checking if all packages depending on it are supported.")
@@ -1212,12 +1253,16 @@ class PrebuildsPlugin : Plugin<Project> {
                     .filter { dependentPackagePatternRegex.matches(it.name) && it.name != packageItem.name }
                     .filterNot { dep -> supportedPackages.any { it.name == dep.name } }
             if (allDependentPackageAreSupported.isNotEmpty()) {
-                unavailablePackages.add(packageItem)
+                fallbackPackages.add(
+                    FallbackReason.DEPENDENCY,
+                    packageItem,
+                    "depended on by ${allDependentPackageAreSupported.joinToString { it.npmName }}",
+                )
                 val patterns = dependentPackagePatterns.joinToString("|")
                 removeCppDependenciesFromSupportedPackages(
                     packageItem,
                     supportedPackages,
-                    unavailablePackages,
+                    fallbackPackages,
                     "Unavailable dependent packages found for ${packageItem.npmName} matching pattern " +
                         "'$patterns': ${printList(allDependentPackageAreSupported)}",
                 )
@@ -1266,7 +1311,7 @@ class PrebuildsPlugin : Plugin<Project> {
         packageItem: PackageItem,
         httpRepositories: List<MavenArtifactRepository>,
         extension: PackagesManager,
-        unavailablePackages: MutableSet<PackageItem>,
+        fallbackPackages: FallbackPackages,
         supportedPackages: MutableSet<PackageItem>,
         elseClosure: () -> Unit,
         project: Project,
@@ -1275,20 +1320,30 @@ class PrebuildsPlugin : Plugin<Project> {
         val checkFailed = !isSpecificCheckPassed(packageItem, extension, supportedPackages, project)
         val isUnavailable = !isPackageAvailable(packageItem, extension.reactNativeVersion, httpRepositories)
 
-        when {
-            isDenied || checkFailed || isUnavailable -> {
-                if (isUnavailable) {
-                    unavailablePackages.add(packageItem)
-                }
-                // Report which of the three checks rejected the package: a deny/allow list rule and a
-                // missing artifact look identical from the build log otherwise, and they need opposite
-                // fixes (edit rnrepo config vs. update the tools/prebuilds version).
+        // A package can trip more than one check (an Expo package is denied *and* has no artifact
+        // published). Report the one the user has to act on first: a deny rule makes the missing
+        // artifact irrelevant, and a failed compatibility check means the artifact was never wanted.
+        val fallbackReason =
+            when {
+                isDenied -> FallbackReason.DENIED
+                checkFailed -> FallbackReason.INCOMPATIBLE
+                isUnavailable -> FallbackReason.UNAVAILABLE
+                else -> null
+            }
+
+        when (fallbackReason) {
+            null -> elseClosure()
+            else -> {
+                fallbackPackages.add(fallbackReason, packageItem)
+                // Spell out which check rejected the package: a deny rule and a missing artifact look
+                // identical from the build log otherwise, and they need opposite fixes (edit rnrepo
+                // config vs. update the tools/prebuilds version).
                 val reason =
-                    when {
-                        isDenied ->
+                    when (fallbackReason) {
+                        FallbackReason.DENIED ->
                             "${packageItem.npmName} is denied by RNRepo configuration (deny list, allow list or built-in " +
                                 "exclusion), so no prebuilt was requested for it."
-                        checkFailed ->
+                        FallbackReason.INCOMPATIBLE ->
                             "${packageItem.npmName} did not pass its package-specific compatibility check " +
                                 "(see the reason logged above, or re-run with --info)."
                         else ->
@@ -1299,11 +1354,10 @@ class PrebuildsPlugin : Plugin<Project> {
                 removeCppDependenciesFromSupportedPackages(
                     packageItem,
                     supportedPackages,
-                    unavailablePackages,
+                    fallbackPackages,
                     reason,
                 )
             }
-            else -> elseClosure()
         }
     }
 
@@ -1318,6 +1372,19 @@ class PrebuildsPlugin : Plugin<Project> {
             "\n  - $icon ${pkg.npmName}@${pkg.version}${pkg.classifier}"
         }
     }
+
+    /**
+     * Same as [printList], but appends the per-package detail explaining the fallback, e.g.
+     * `- ⛓️ react-native-reanimated@4.3.1 (depends on react-native-worklets)`.
+     */
+    private fun printFallbackList(
+        packages: Map<PackageItem, String>,
+        icon: String,
+    ): String =
+        packages.entries.joinToString("") { (pkg, detail) ->
+            val suffix = if (detail.isEmpty()) "" else " ($detail)"
+            "\n  - $icon ${pkg.npmName}@${pkg.version}${pkg.classifier}$suffix"
+        }
 
     /**
      * Determines which packages are available as prebuilt AARs.
@@ -1337,9 +1404,7 @@ class PrebuildsPlugin : Plugin<Project> {
         val supportedPackages =
             java.util.concurrent.ConcurrentHashMap
                 .newKeySet<PackageItem>()
-        val unavailablePackages =
-            java.util.concurrent.ConcurrentHashMap
-                .newKeySet<PackageItem>()
+        val fallbackPackages = FallbackPackages()
         val httpRepositories = resolveRNRepoRepositories(project.repositories)
         val (dependentList, otherPackages) = extension.projectPackages.partition { PACKAGES_WITH_CPP.containsKey(it.name) }
         otherPackages.parallelStream().forEach { packageItem ->
@@ -1347,7 +1412,7 @@ class PrebuildsPlugin : Plugin<Project> {
                 packageItem,
                 httpRepositories,
                 extension,
-                unavailablePackages,
+                fallbackPackages,
                 supportedPackages,
                 { supportedPackages.add(packageItem) },
                 project,
@@ -1359,13 +1424,13 @@ class PrebuildsPlugin : Plugin<Project> {
                 logger.info(
                     "${packageItem.npmName} has dependencies with C++ code, checking availability of dependent packages...",
                 )
-                checkDependenciesLocal(packageItem, project, supportedPackages, unavailablePackages, extension.projectPackages)
+                checkDependenciesLocal(packageItem, project, supportedPackages, fallbackPackages, extension.projectPackages)
             }
             checkIfPackageIsSupported(
                 packageItem,
                 httpRepositories,
                 extension,
-                unavailablePackages,
+                fallbackPackages,
                 supportedPackages,
                 elseClosure,
                 project,
@@ -1374,7 +1439,18 @@ class PrebuildsPlugin : Plugin<Project> {
 
         extension.supportedPackages = supportedPackages
         logger.lifecycle("Found the following supported prebuilt packages:${printList(extension.supportedPackages, "📦")}")
-        logger.lifecycle("Packages that fallback to building from sources:${printList(unavailablePackages, "❓")}")
+        if (fallbackPackages.isEmpty()) {
+            logger.lifecycle("Packages that fallback to building from sources:${printList(emptyList())}")
+            return
+        }
+        // One list per reason, so it is clear whether a package needs a config change, a newer
+        // @rnrepo/build-tools, or nothing at all (it follows a dependency that is not prebuilt).
+        FallbackReason.values().forEach { reason ->
+            val packages = fallbackPackages.get(reason)
+            if (packages.isNotEmpty()) {
+                logger.lifecycle("${reason.heading}:${printFallbackList(packages, reason.icon)}")
+            }
+        }
     }
 
     private fun configureReactNativeAutolinkingTask(

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/FallbackPackagesTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/FallbackPackagesTest.kt
@@ -1,0 +1,55 @@
+package org.rnrepo.tools.prebuilds
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FallbackPackagesTest {
+    private fun pkg(name: String) = PackageItem(name = name, version = "1.0.0", npmName = name)
+
+    @Test
+    fun `isEmpty is true only before any package is added`() {
+        val fallback = FallbackPackages()
+        assertThat(fallback.isEmpty()).isTrue()
+
+        fallback.add(FallbackReason.DENIED, pkg("expo-camera"))
+        assertThat(fallback.isEmpty()).isFalse()
+    }
+
+    @Test
+    fun `packages are grouped under the reason they were added with`() {
+        val fallback = FallbackPackages()
+        val denied = pkg("expo-camera")
+        val unavailable = pkg("react-native-svg")
+        fallback.add(FallbackReason.DENIED, denied, "deny list")
+        fallback.add(FallbackReason.UNAVAILABLE, unavailable)
+
+        assertThat(fallback.get(FallbackReason.DENIED)).containsOnlyKeys(denied)
+        assertThat(fallback.get(FallbackReason.DENIED)[denied]).isEqualTo("deny list")
+        assertThat(fallback.get(FallbackReason.UNAVAILABLE)).containsOnlyKeys(unavailable)
+        assertThat(fallback.get(FallbackReason.INCOMPATIBLE)).isEmpty()
+        assertThat(fallback.get(FallbackReason.DEPENDENCY)).isEmpty()
+    }
+
+    @Test
+    fun `addAll stores the same detail for every package`() {
+        val fallback = FallbackPackages()
+        val packages = listOf(pkg("react-native-reanimated"), pkg("expensify_react-native-live-markdown"))
+        fallback.addAll(FallbackReason.DEPENDENCY, packages, "depends on react-native-worklets")
+
+        assertThat(fallback.get(FallbackReason.DEPENDENCY).values)
+            .containsOnly("depends on react-native-worklets")
+        assertThat(fallback.get(FallbackReason.DEPENDENCY)).hasSize(2)
+    }
+
+    @Test
+    fun `re-adding a package replaces its detail without duplicating the entry`() {
+        val fallback = FallbackPackages()
+        val item = pkg("react-native-reanimated")
+        fallback.add(FallbackReason.DEPENDENCY, item, "depends on react-native-worklets")
+        fallback.add(FallbackReason.DEPENDENCY, item, "depends on react-native-firebase_app")
+
+        assertThat(fallback.get(FallbackReason.DEPENDENCY)).hasSize(1)
+        assertThat(fallback.get(FallbackReason.DEPENDENCY)[item])
+            .isEqualTo("depends on react-native-firebase_app")
+    }
+}

--- a/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
+++ b/packages/build-tools/gradle-plugin/src/test/kotlin/org/rnrepo/tools/prebuilds/PrebuildsPluginHelperMethodsTest.kt
@@ -371,32 +371,41 @@ class PrebuildsPluginHelperMethodsTest {
     }
 
     @Test
-    fun `isPackageNotDenied should return false for denied packages`() {
+    fun `deniedReason should name the denying rule for denied packages`() {
         // Given
         val extension = PackagesManager()
         extension.denyList = setOf("react-native-vector-icons", "react-native-image-picker")
 
         // When
         val result1 =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isPackageNotDenied",
+                "deniedReason",
                 arrayOf(String::class.java, PackagesManager::class.java),
                 "react-native-vector-icons",
                 extension,
             )
         val result2 =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isPackageNotDenied",
+                "deniedReason",
                 arrayOf(String::class.java, PackagesManager::class.java),
                 "react-native-reanimated",
                 extension,
             )
+        val result3 =
+            invokePrivateMethod<String?>(
+                plugin,
+                "deniedReason",
+                arrayOf(String::class.java, PackagesManager::class.java),
+                "expo-camera",
+                extension,
+            )
 
         // Then
-        assertThat(result1).isFalse()
-        assertThat(result2).isTrue()
+        assertThat(result1).isEqualTo("deny list")
+        assertThat(result2).isNull()
+        assertThat(result3).isEqualTo("built-in Expo exclusion")
     }
 
     @Test
@@ -465,7 +474,7 @@ class PrebuildsPluginHelperMethodsTest {
     }
 
     @Test
-    fun `isSpecificCheckPassed should handle react-native-reanimated with worklets`() {
+    fun `specificCheckFailureReason should handle react-native-reanimated with worklets`() {
         // Given
         val extension = PackagesManager()
         val reanimatedPackage = PackageItem("react-native-reanimated", "4.2.0", "react-native-reanimated")
@@ -476,9 +485,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 reanimatedPackage,
                 extension,
@@ -487,12 +496,12 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isNull()
         assertThat(reanimatedPackage.classifier).isEqualTo("-worklets1.0.0")
     }
 
     @Test
-    fun `isSpecificCheckPassed should handle react-native-reanimated without worklets`() {
+    fun `specificCheckFailureReason should handle react-native-reanimated without worklets`() {
         // Given
         val extension = PackagesManager()
         val reanimatedPackage = PackageItem("react-native-reanimated", "4.2.0", "react-native-reanimated")
@@ -502,9 +511,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 reanimatedPackage,
                 extension,
@@ -513,11 +522,11 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo("requires react-native-worklets in the project")
     }
 
     @Test
-    fun `isSpecificCheckPassed should handle react-native-reanimated4-3-0 without worklets`() {
+    fun `specificCheckFailureReason should handle react-native-reanimated4-3-0 without worklets`() {
         // Given
         val extension = PackagesManager()
         val reanimatedPackage = PackageItem("react-native-reanimated", "4.5.0", "react-native-reanimated")
@@ -527,9 +536,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 reanimatedPackage,
                 extension,
@@ -538,11 +547,11 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `isSpecificCheckPassed should handle react-native-reanimated3 without worklets`() {
+    fun `specificCheckFailureReason should handle react-native-reanimated3 without worklets`() {
         // Given
         val extension = PackagesManager()
         val reanimatedPackage = PackageItem("react-native-reanimated", "3.5.0", "react-native-reanimated")
@@ -552,9 +561,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 reanimatedPackage,
                 extension,
@@ -563,11 +572,11 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `isSpecificCheckPassed should handle react-native-gesture-handler dependencies`() {
+    fun `specificCheckFailureReason should handle react-native-gesture-handler dependencies`() {
         // Given
         val extension = PackagesManager()
         val gestureHandlerPackage = PackageItem("react-native-gesture-handler", "2.8.0", "react-native-gesture-handler")
@@ -579,9 +588,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 gestureHandlerPackage,
                 extension,
@@ -590,11 +599,11 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `isSpecificCheckPassed should allow react-native-worklets with expo55 in release build`() {
+    fun `specificCheckFailureReason should allow react-native-worklets with expo55 in release build`() {
         // Given
         val extension = PackagesManager()
         val workletsPackage = PackageItem("react-native-worklets", "1.0.0", "react-native-worklets")
@@ -606,9 +615,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 workletsPackage,
                 extension,
@@ -617,11 +626,11 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isNull()
     }
 
     @Test
-    fun `isSpecificCheckPassed should deny react-native-worklets with expo55 in debug build`() {
+    fun `specificCheckFailureReason should deny react-native-worklets with expo55 in debug build`() {
         // Given
         val extension = PackagesManager()
         val workletsPackage = PackageItem("react-native-worklets", "1.0.0", "react-native-worklets")
@@ -633,9 +642,9 @@ class PrebuildsPluginHelperMethodsTest {
 
         // When
         val result =
-            invokePrivateMethod<Boolean>(
+            invokePrivateMethod<String?>(
                 plugin,
-                "isSpecificCheckPassed",
+                "specificCheckFailureReason",
                 arrayOf(PackageItem::class.java, PackagesManager::class.java, Set::class.java, Project::class.java),
                 workletsPackage,
                 extension,
@@ -644,7 +653,7 @@ class PrebuildsPluginHelperMethodsTest {
             )
 
         // Then
-        assertThat(result).isFalse()
+        assertThat(result).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
## 📝 Description

Better logging to see why artifacts is not used when available.

Info #435

## 🧪 Testing

- before
  - ```text
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-screens@4.26.2
      - 📦 @react-native-masked-view/masked-view@0.3.2
      - 📦 react-native-gesture-handler@2.31.2
      - 📦 react-native-safe-area-context@5.7.0
    [📦 RNRepo] Packages that fallback to building from sources:
      - ❓ expo@56.0.18
      - ❓ @expo/log-box@56.0.14
      - ❓ expo-constants@56.0.22
      - ❓ expo-modules-core@56.0.22
      - ❓ react-native-reanimated@4.3.1
    ```
- after
  - ```
    [📦 RNRepo] Found the following supported prebuilt packages:
      - 📦 react-native-screens@4.26.2
      - 📦 @react-native-masked-view/masked-view@0.3.2
      - 📦 react-native-gesture-handler@2.31.2
      - 📦 react-native-safe-area-context@5.7.0
    [📦 RNRepo] Packages denied by configuration (deny/allow list or built-in rule):
      - 🚫 expo@56.0.18 (built-in Expo exclusion)
      - 🚫 @expo/log-box@56.0.14 (built-in Expo exclusion)
      - 🚫 expo-constants@56.0.22 (built-in Expo exclusion)
    [📦 RNRepo] Packages with no matching prebuilt artifact published:
      - ❓ @react-native-firebase/auth@26.0.0
    [📦 RNRepo] Packages that failed a compatibility check:
      - ⚠️ react-native-worklets@0.8.3 (Expo 55+ debug builds need worklets from sources while expo-modules-core is not prebuilt)
      - ⚠️ expo-modules-core@56.0.22 (prebuilt is not supported in debug builds)
    [📦 RNRepo] Packages with a prebuilt available, kept on sources to stay compatible with other packages:
      - ⛓️ @react-native-firebase/messaging@26.0.0 (depends on @react-native-firebase/app)
      - ⛓️ @react-native-firebase/app@26.0.0 (depended on by @react-native-firebase/auth)
      - ⛓️ react-native-reanimated@4.3.1 (depends on react-native-worklets)
    ```
