### PR TITLE
chore: pass GL_TOKEN to dependency installs in CI

### DIFF
--- a/.github/workflows/build-library-android.yml
+++ b/.github/workflows/build-library-android.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: ♻️ Restore RN project cache
         id: rn-project-cache

--- a/.github/workflows/build-library-ios.yml
+++ b/.github/workflows/build-library-ios.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: ♻️ Restore RN project cache
         id: rn-project-cache

--- a/.github/workflows/check-build-consistency.yml
+++ b/.github/workflows/check-build-consistency.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔍 Run consistency check
         env:

--- a/.github/workflows/check-failed-builds.yml
+++ b/.github/workflows/check-failed-builds.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔍 Check failed builds
         env:

--- a/.github/workflows/daily-react-native-version-check.yml
+++ b/.github/workflows/daily-react-native-version-check.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔍 Check and update React Native versions
         run: bun run packages/scheduler/src/update-react-native-versions.ts

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: Build
         run: bun run build

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔍 Lint kotlin
         if: ${{ steps.filter.outputs.kotlin == 'true' }}

--- a/.github/workflows/publish-expo-config-plugin.yml
+++ b/.github/workflows/publish-expo-config-plugin.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔨 Build plugin
         run: bun run build

--- a/.github/workflows/publish-library-android.yml
+++ b/.github/workflows/publish-library-android.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 📝 Update build status (failure)
         run: bun run packages/publisher/update-build-status.ts -- "${WORKFLOW_RUN_ID}" "failed"
@@ -86,6 +88,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔐 Import GPG key
         env:

--- a/.github/workflows/publish-library-ios.yml
+++ b/.github/workflows/publish-library-ios.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 📝 Update build status (failure)
         run: bun run packages/publisher/update-build-status.ts -- "${WORKFLOW_RUN_ID}" "failed"
@@ -86,6 +88,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔐 Import GPG key
         env:

--- a/.github/workflows/run-scheduler.yml
+++ b/.github/workflows/run-scheduler.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --ignore-scripts
+        env:
+          GL_TOKEN: ${{ secrets.GL_TOKEN }}
 
       - name: 🔄 Run scheduler
         env:


### PR DESCRIPTION
## 📝 Description

In #445 the website is moving onto `@swmansion/ui-components`, which is published to the
private GitLab package registry. `.npmrc` maps the `@swmansion`
scope to that registry and reads the auth token from `${GL_TOKEN}`, but no
workflow sets that variable today, so CI installs unauthenticated and the
registry answers 401:

error: GET https://gl.swmansion.com/api/v4/projects/682/packages/npm/@swmansion%2fui-components - 401
error: @swmansion/ui-components@^1.0.59 failed to resolve in lint-and-validate

This adds `GL_TOKEN` to every step that runs the workspace install.


All 13 install steps are covered, not just `lint-and-validate` - each one runs
the root bun install, which resolves packages/website too, so every workflow
would hit the same 401. 

⚠️ Someone with admin access needs to add a `GL_TOKEN` repository secret. I got the token, but cannot add it without repo permissions.

⚠️ This PR should be merged before #445.

🧪 Testing

1. Add the `GL_TOKEN` secret.
2. Re-run CI on the website migration PR — `bun install` resolves
   `@swmansion/ui-components` instead of failing with a 401.